### PR TITLE
Updated MAINTAINERS.md format.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,14 +1,16 @@
-# OpenSearch dashboards-query-workbench Maintainers
+## Overview
 
-## Maintainers
+This document contains a list of maintainers in this repo. See [opensearch-project/.github/RESPONSIBILITIES.md](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities) that explains what the role of maintainer means, what maintainers do in this and other repos, and how they should be doing it. If you're interested in contributing, and becoming a maintainer, see [CONTRIBUTING](CONTRIBUTING.md).
 
-| Maintainer | GitHub ID | Affiliation |
-| --------------- | --------- | ----------- |
-| Anirudha (Ani) Jadhav | [anirudha](https://github.com/anirudha) | Amazon |
-| Peng Huo | [penghuo](https://github.com/penghuo) | Amazon |
-| Chen Dai | [dai-chen](https://github.com/dai-chen) | Amazon |
-| Chloe Zhang | [chloe-zh](https://github.com/chloe-zh) | Amazon |
-| Nick Knize | [nknize](https://github.com/nknize) | Amazon |
-| Charlotte Henkle | [CEHENKLE](https://github.com/CEHENKLE) | Amazon |
-| Max Ksyunz |  [MaxKsyunz](https://github.com/MaxKsyunz) | BitQuill |
-| Yury Fridlyand | [Yury-Fridlyand](https://github.com/Yury-Fridlyand) | BitQuill |
+## Current Maintainers
+
+| Maintainer            | GitHub ID                                           | Affiliation |
+| --------------------- | --------------------------------------------------- | ----------- |
+| Anirudha (Ani) Jadhav | [anirudha](https://github.com/anirudha)             | Amazon      |
+| Peng Huo              | [penghuo](https://github.com/penghuo)               | Amazon      |
+| Chen Dai              | [dai-chen](https://github.com/dai-chen)             | Amazon      |
+| Chloe Zhang           | [chloe-zh](https://github.com/chloe-zh)             | Amazon      |
+| Nick Knize            | [nknize](https://github.com/nknize)                 | Amazon      |
+| Charlotte Henkle      | [CEHENKLE](https://github.com/CEHENKLE)             | Amazon      |
+| Max Ksyunz            | [MaxKsyunz](https://github.com/MaxKsyunz)           | BitQuill    |
+| Yury Fridlyand        | [Yury-Fridlyand](https://github.com/Yury-Fridlyand) | BitQuill    |


### PR DESCRIPTION
Coming from https://github.com/opensearch-project/.github/issues/121, updated MAINTAINERS.md to match opensearch-project recommended format.