### PR TITLE
Add fix for CVE-2023-2251

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "ansi-regex": "^5.0.1",
     "eslint-utils": "^2.0.0",
     "json-schema": "^0.4.0",
-    "**/@types/react": "16.3.14"
+    "**/@types/react": "16.3.14",
+    "yaml": "^2.2.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2852,10 +2852,10 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@^1.10.0:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
-  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+yaml@^1.10.0, yaml@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.2.tgz#ec551ef37326e6d42872dad1970300f8eb83a073"
+  integrity sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==
 
 yargs-parser@20.x:
   version "20.2.9"


### PR DESCRIPTION
### Description
- Added resolution for yaml v2.2.2
```
yarn why v1.22.19
[1/4] Why do we have the module "yaml"...?
[2/4] Initialising dependency graph...
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "yaml@1.10.2"
info Reasons this module exists
   - "husky#cosmiconfig" depends on it
   - Hoisted from "husky#cosmiconfig#yaml"
info Disk size without dependencies: "640KB"
info Disk size with unique dependencies: "640KB"
info Disk size with transitive dependencies: "640KB"
info Number of shared dependencies: 0
Done in 0.21s.

```
 
### Issues Resolved
CVE-2023-2251
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).