### PR TITLE
Update default query

### DIFF
--- a/public/components/Main/main.tsx
+++ b/public/components/Main/main.tsx
@@ -203,7 +203,7 @@ export class Main extends React.Component<MainProps, MainState> {
     this.onChange = this.onChange.bind(this);
     this.state = {
       language: 'SQL',
-      sqlQueriesString: 'SHOW tables LIKE %;',
+      sqlQueriesString: 'SHOW tables LIKE \'%\';',
       pplQueriesString: '',
       queries: [],
       queryTranslations: [],


### PR DESCRIPTION
### Description
`SHOW TABLES LIKE %` query was used as a default query. As of https://github.com/opensearch-project/sql/pull/1181, query syntax changed in V2. This query was falling back to V1 SQL plugin engine, which would be deprecated once upon a time. Updating this query in the workbench ensures that SQL plugin would properly respond to it.

### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).