### PR TITLE
Load table fields for acceleration index flyout

### DIFF
--- a/public/components/acceleration/selectors/index_type_selector.tsx
+++ b/public/components/acceleration/selectors/index_type_selector.tsx
@@ -18,7 +18,11 @@ import {
   ACCELERATION_INDEX_TYPES,
   ACC_INDEX_TYPE_DOCUMENTATION_URL,
 } from '../../../../common/constants';
-import { AccelerationIndexType, CreateAccelerationForm } from '../../../../common/types';
+import {
+  AccelerationIndexType,
+  CreateAccelerationForm,
+  DataTableFieldsType,
+} from '../../../../common/types';
 import { getJobId, pollQueryStatus } from '../../SQLPage/utils';
 
 interface IndexTypeSelectorProps {
@@ -48,22 +52,16 @@ export const IndexTypeSelector = ({
       };
       getJobId(query, http, (id: string) => {
         pollQueryStatus(id, http, (data: any[]) => {
+          let dataTableFields: DataTableFieldsType[] = [];
+          if (data.length > 0)
+            dataTableFields = data.map((field, index) => ({
+              id: `${idPrefix}${index + 1}`,
+              fieldName: field.col_name,
+              dataType: field.data_type,
+            }));
           setAccelerationFormData({
             ...accelerationFormData,
-            dataTableFields: [
-              { id: `${idPrefix}1`, fieldName: 'Field1', dataType: 'Integer' },
-              { id: `${idPrefix}2`, fieldName: 'Field2', dataType: 'Integer' },
-              { id: `${idPrefix}3`, fieldName: 'Field3', dataType: 'Integer' },
-              { id: `${idPrefix}4`, fieldName: 'Field4', dataType: 'Integer' },
-              { id: `${idPrefix}5`, fieldName: 'Field5', dataType: 'Integer' },
-              { id: `${idPrefix}6`, fieldName: 'Field6', dataType: 'Integer' },
-              { id: `${idPrefix}7`, fieldName: 'Field7', dataType: 'Integer' },
-              { id: `${idPrefix}8`, fieldName: 'Field8', dataType: 'Integer' },
-              { id: `${idPrefix}9`, fieldName: 'Field9', dataType: 'Integer' },
-              { id: `${idPrefix}10`, fieldName: 'Field10', dataType: 'Integer' },
-              { id: `${idPrefix}11`, fieldName: 'Field11', dataType: 'Integer' },
-              { id: `${idPrefix}12`, fieldName: 'Field12', dataType: 'TimestampType' },
-            ],
+            dataTableFields: dataTableFields,
           });
           setLoading(false);
         });

--- a/public/components/acceleration/selectors/index_type_selector.tsx
+++ b/public/components/acceleration/selectors/index_type_selector.tsx
@@ -52,13 +52,11 @@ export const IndexTypeSelector = ({
       };
       getJobId(query, http, (id: string) => {
         pollQueryStatus(id, http, (data: any[]) => {
-          let dataTableFields: DataTableFieldsType[] = [];
-          if (data.length > 0)
-            dataTableFields = data.map((field, index) => ({
-              id: `${idPrefix}${index + 1}`,
-              fieldName: field.col_name,
-              dataType: field.data_type,
-            }));
+          const dataTableFields: DataTableFieldsType[] = data.map((field, index) => ({
+            id: `${idPrefix}${index + 1}`,
+            fieldName: field.col_name,
+            dataType: field.data_type,
+          }));
           setAccelerationFormData({
             ...accelerationFormData,
             dataTableFields: dataTableFields,


### PR DESCRIPTION
### Description
Load table fields for acceleration index flyout
 
 Assumes backend response form https://github.com/opensearch-project/sql/issues/2210: 
 ```
 const result  = [
  { col_name: '@timestamp', data_type: 'timestamp' },
  { col_name: 'clientip', data_type: 'string' },
  { col_name: 'request', data_type: 'string' },
  { col_name: 'status', data_type: 'int' },
  { col_name: 'size', data_type: 'int' },
  { col_name: 'year', data_type: 'int' },
  { col_name: 'month', data_type: 'int' },
  { col_name: 'day', data_type: 'int' },
  { col_name: 'year', data_type: 'int' },
  { col_name: 'month', data_type: 'int' },
  { col_name: 'day', data_type: 'int' },
];
```
### Issues Resolved
#127 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).