### PR TITLE
Add backticks and remove ckpt for manual refresh in acceleration flyout

### DIFF
--- a/public/components/acceleration/visual_editors/__tests__/query_builder.test.tsx
+++ b/public/components/acceleration/visual_editors/__tests__/query_builder.test.tsx
@@ -13,11 +13,13 @@ import {
   indexOptionsMock3,
   indexOptionsMock4,
   indexOptionsMock5,
+  indexOptionsMock6,
   indexOptionsMockResult1,
   indexOptionsMockResult2,
   indexOptionsMockResult3,
   indexOptionsMockResult4,
   indexOptionsMockResult5,
+  indexOptionsMockResult6,
   materializedViewBuilderMock1,
   materializedViewBuilderMock2,
   materializedViewBuilderMockResult1,
@@ -58,6 +60,11 @@ describe('buildIndexOptions', () => {
   it('should build index options with watermark delay', () => {
     const indexOptions = buildIndexOptions(indexOptionsMock5);
     expect(indexOptions).toEqual(indexOptionsMockResult5);
+  });
+
+  it('should build index options with manual refresh and checkpoint', () => {
+    const indexOptions = buildIndexOptions(indexOptionsMock6);
+    expect(indexOptions).toEqual(indexOptionsMockResult6);
   });
 
   describe('skippingIndexQueryBuilder', () => {

--- a/public/components/acceleration/visual_editors/query_builder.tsx
+++ b/public/components/acceleration/visual_editors/query_builder.tsx
@@ -46,7 +46,7 @@ export const buildIndexOptions = (accelerationformData: CreateAccelerationForm) 
     );
   }
 
-  if (checkpointLocation) {
+  if (refreshType !== 'manual' && checkpointLocation) {
     // Add checkpoint location option
     indexOptions.push(`checkpoint_location = '${checkpointLocation}'`);
   }

--- a/public/components/acceleration/visual_editors/query_builder.tsx
+++ b/public/components/acceleration/visual_editors/query_builder.tsx
@@ -58,7 +58,7 @@ export const buildIndexOptions = (accelerationformData: CreateAccelerationForm) 
 /* Add skipping index columns to query */
 const buildSkippingIndexColumns = (skippingIndexQueryData: SkippingIndexRowType[]) => {
   return skippingIndexQueryData
-    .map((n) => `   ${n.fieldName} ${n.accelerationMethod}`)
+    .map((n) => `   \`${n.fieldName}\` ${n.accelerationMethod}`)
     .join(', \n');
 };
 
@@ -68,9 +68,9 @@ const buildSkippingIndexColumns = (skippingIndexQueryData: SkippingIndexRowType[
  *
  * CREATE SKIPPING INDEX
  * ON datasource.database.table (
- *    field1 VALUE_SET,
- *    field2 PARTITION,
- *    field3 MIN_MAX,
+ *    `field1` VALUE_SET,
+ *    `field2` PARTITION,
+ *    `field3` MIN_MAX,
  * ) WITH (
  * auto_refresh = true,
  * refresh_interval = '1 minute',
@@ -91,7 +91,7 @@ ${buildSkippingIndexColumns(skippingIndexQueryData)}
 
 /* Add covering index columns to query */
 const buildCoveringIndexColumns = (coveringIndexQueryData: string[]) => {
-  return coveringIndexQueryData.map((field) => `   ${field}`).join(', \n');
+  return coveringIndexQueryData.map((field) => `   \`${field}\``).join(', \n');
 };
 
 /*
@@ -100,9 +100,9 @@ const buildCoveringIndexColumns = (coveringIndexQueryData: string[]) => {
  *
  * CREATE INDEX index_name
  * ON datasource.database.table (
- *    field1,
- *    field2,
- *    field3,
+ *    `field1`,
+ *    `field2`,
+ *    `field3`,
  * ) WITH (
  * auto_refresh = true,
  * refresh_interval = '1 minute',
@@ -127,12 +127,16 @@ ${buildCoveringIndexColumns(coveringIndexQueryData)}
   return codeQuery;
 };
 
+const buildMaterializedViewColumnName = (columnName: string) => {
+  return columnName === '*' ? columnName : `\`${columnName}\``;
+};
+
 const buildMaterializedViewColumns = (columnsValues: MaterializedViewColumn[]) => {
   return columnsValues
     .map(
       (column) =>
-        `   ${column.functionName}(${column.functionParam})${
-          column.fieldAlias ? ` AS ${column.fieldAlias}` : ``
+        `   ${column.functionName}(${buildMaterializedViewColumnName(column.functionParam)})${
+          column.fieldAlias ? ` AS \`${column.fieldAlias}\`` : ``
         }`
     )
     .join(', \n');
@@ -141,7 +145,7 @@ const buildMaterializedViewColumns = (columnsValues: MaterializedViewColumn[]) =
 /* Build group by tumble values */
 const buildTumbleValue = (GroupByTumbleValue: GroupByTumbleType) => {
   const { timeField, tumbleWindow, tumbleInterval } = GroupByTumbleValue;
-  return `(${timeField}, '${tumbleWindow} ${tumbleInterval}${pluralizeTime(tumbleWindow)}')`;
+  return `(\`${timeField}\`, '${tumbleWindow} ${tumbleInterval}${pluralizeTime(tumbleWindow)}')`;
 };
 
 /*
@@ -150,10 +154,10 @@ const buildTumbleValue = (GroupByTumbleValue: GroupByTumbleType) => {
  *
  * CREATE MATERIALIZED VIEW datasource.database.index_name
  * AS SELECT
- * count(field) as counter,
- * count(*) as counter1,
- * sum(field2),
- * avg(field3) as average
+ * count(`field`) as `counter`,
+ * count(*) as `counter1`,
+ * sum(`field2`),
+ * avg(`field3`) as `average`
  *  WITH (
  * auto_refresh = true,
  * refresh_interval = '1 minute',

--- a/test/mocks/accelerationMock.ts
+++ b/test/mocks/accelerationMock.ts
@@ -238,9 +238,9 @@ export const skippingIndexBuilderMock1: CreateAccelerationForm = {
 
 export const skippingIndexBuilderMockResult1 = `CREATE SKIPPING INDEX
 ON datasource.database.table (
-   field1 PARTITION, 
-   field2 VALUE_SET, 
-   field3 MIN_MAX
+   \`field1\` PARTITION, 
+   \`field2\` VALUE_SET, 
+   \`field3\` MIN_MAX
   ) WITH (
 index_settings = '{"number_of_shards":9,"number_of_replicas":2}',
 auto_refresh = true,
@@ -269,7 +269,7 @@ export const skippingIndexBuilderMock2: CreateAccelerationForm = {
 
 export const skippingIndexBuilderMockResult2 = `CREATE SKIPPING INDEX
 ON datasource.database.table (
-   field1 PARTITION
+   \`field1\` PARTITION
   ) WITH (
 index_settings = '{"number_of_shards":5,"number_of_replicas":3}',
 auto_refresh = true,
@@ -295,9 +295,9 @@ export const coveringIndexBuilderMock1: CreateAccelerationForm = {
 
 export const coveringIndexBuilderMockResult1 = `CREATE INDEX index_name
 ON datasource.database.table (
-   field1, 
-   field2, 
-   field3
+   \`field1\`, 
+   \`field2\`, 
+   \`field3\`
   ) WITH (
 index_settings = '{"number_of_shards":9,"number_of_replicas":2}',
 auto_refresh = true,
@@ -320,7 +320,7 @@ export const coveringIndexBuilderMock2: CreateAccelerationForm = {
 
 export const coveringIndexBuilderMockResult2 = `CREATE INDEX index_name
 ON datasource.database.table (
-   field1
+   \`field1\`
   ) WITH (
 index_settings = '{"number_of_shards":5,"number_of_replicas":3}',
 auto_refresh = true,
@@ -363,12 +363,12 @@ export const materializedViewBuilderMock1: CreateAccelerationForm = {
 
 export const materializedViewBuilderMockResult1 = `CREATE MATERIALIZED VIEW datasource.database.index_name
 AS SELECT
-   count(field) AS counter, 
-   count(*) AS counter1, 
-   sum(field2), 
-   avg(field3) AS average
+   count(\`field\`) AS \`counter\`, 
+   count(*) AS \`counter1\`, 
+   sum(\`field2\`), 
+   avg(\`field3\`) AS \`average\`
 FROM datasource.database.table
-GROUP BY TUMBLE (timestamp, '1 minute')
+GROUP BY TUMBLE (\`timestamp\`, '1 minute')
  WITH (
 index_settings = '{"number_of_shards":9,"number_of_replicas":2}',
 auto_refresh = true,
@@ -404,9 +404,9 @@ export const materializedViewBuilderMock2: CreateAccelerationForm = {
 
 export const materializedViewBuilderMockResult2 = `CREATE MATERIALIZED VIEW datasource.database.index_name
 AS SELECT
-   count(field)
+   count(\`field\`)
 FROM datasource.database.table
-GROUP BY TUMBLE (timestamp, '2 hours')
+GROUP BY TUMBLE (\`timestamp\`, '2 hours')
  WITH (
 index_settings = '{"number_of_shards":5,"number_of_replicas":3}',
 auto_refresh = true,

--- a/test/mocks/accelerationMock.ts
+++ b/test/mocks/accelerationMock.ts
@@ -236,6 +236,19 @@ export const skippingIndexBuilderMock1: CreateAccelerationForm = {
   checkpointLocation: 's3://test/',
 };
 
+export const indexOptionsMock6: CreateAccelerationForm = {
+  ...createAccelerationEmptyDataMock,
+  primaryShardsCount: 1,
+  replicaShardsCount: 1,
+  refreshType: 'manual',
+  checkpointLocation: 's3://dsfsad/dasda',
+};
+
+export const indexOptionsMockResult6 = `WITH (
+index_settings = '{"number_of_shards":1,"number_of_replicas":1}',
+auto_refresh = false
+)`;
+
 export const skippingIndexBuilderMockResult1 = `CREATE SKIPPING INDEX
 ON datasource.database.table (
    \`field1\` PARTITION, 


### PR DESCRIPTION
### Description

1. Add backticks to columns for acceleration flyout
2. remove redundant checkpoint for manual refresh

### Issues Resolved
#127 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).