### PR TITLE
[CI/CD] Add E2E Cypress workflow for sql workbench

### DIFF
--- a/.github/workflows/cypress-e2e-sql-workbench-test.yml
+++ b/.github/workflows/cypress-e2e-sql-workbench-test.yml
@@ -79,18 +79,7 @@ jobs:
       - name: Checkout Query Workbench in OpenSearch Dashboards Plugins Dir
         uses: actions/checkout@v2
         with:
-            path: OpenSearch-Dashboards/plugins
-
-      - name: DEBUGGING 1
-        run: |
-          pwd
-          ls
-
-      - name: DEBUGGING 1
-        run: |
-          cd ./OpenSearch-Dashboards/plugins
-          pwd
-          ls
+            path: OpenSearch-Dashboards/plugins/dashboards-query-workbench
 
       - id: tool-versions
         run: |

--- a/.github/workflows/cypress-e2e-sql-workbench-test.yml
+++ b/.github/workflows/cypress-e2e-sql-workbench-test.yml
@@ -81,6 +81,17 @@ jobs:
         with:
             path: OpenSearch-Dashboards/plugins
 
+      - name: DEBUGGING 1
+        run: |
+          pwd
+          ls
+
+      - name: DEBUGGING 1
+        run: |
+          cd ./OpenSearch-Dashboards/plugins
+          pwd
+          ls
+
       - id: tool-versions
         run: |
           echo "node_version=$(cat .node-version)" >> $GITHUB_OUTPUT

--- a/.github/workflows/cypress-e2e-sql-workbench-test.yml
+++ b/.github/workflows/cypress-e2e-sql-workbench-test.yml
@@ -1,0 +1,156 @@
+name: Cypress E2E SQL Workbench Test
+
+on: [pull_request, push]
+
+env:
+  CI: 1
+  # avoid warnings like "tput: No value for $TERM and no -T specified"
+  TERM: xterm
+  OPENSEARCH_DASHBOARDS_VERSION: 'main'
+  OPENSEARCH_VERSION: '3.0.0'
+  OPENSEARCH_PLUGIN_VERSION: '3.0.0.0'
+
+jobs:
+  tests:
+    name: Run Cypress E2E SQL Workbench tests
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest ]
+        jdk: [ 11 ]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.jdk }}
+
+      - name: Download SQL artifact
+        uses: suisei-cn/actions-download-file@v1.4.0
+        with:
+          url: https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-sql-plugin&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip
+          target: plugin-artifacts/
+          filename: sql.zip
+
+      - name: Download OpenSearch
+        uses: peternied/download-file@v2
+        with:
+          url: https://artifacts.opensearch.org/snapshots/core/opensearch/${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/opensearch-min-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT-linux-x64-latest.tar.gz
+  
+      - name: Extract OpenSearch
+        run: |
+          tar -xzf opensearch-*.tar.gz
+          rm -f opensearch-*.tar.gz
+        shell: bash
+      
+      - name: Install SQL plugin
+        run: |
+          /bin/bash -c "yes | ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/bin/opensearch-plugin install file:$(pwd)/plugin-artifacts/sql.zip"
+        shell: bash
+    
+      - name: Run OpenSearch
+        run: |
+          /bin/bash -c "./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/bin/opensearch &"
+          sleep 30
+        shell: bash
+    
+      - name: Check OpenSearch Running on Linux
+        if: ${{ runner.os != 'Windows'}}
+        run: curl http://localhost:9200/
+        shell: bash
+      
+      - name: Show OpenSearch Logs
+        if: always()
+        run: cat ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/logs/opensearch.log
+        shell: bash
+      
+      - name: Checkout OpenSearch Dashboards
+        uses: actions/checkout@v2
+        with:
+          path: OpenSearch-Dashboards
+          repository: opensearch-project/OpenSearch-Dashboards
+          ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
+          fetch-depth: 0
+          filter: |
+            cypress
+            test
+
+      - name: Checkout Query Workbench in OpenSearch Dashboards Plugins Dir
+        uses: actions/checkout@v2
+        with:
+            path: OpenSearch-Dashboards/plugins
+
+      - id: tool-versions
+        run: |
+          echo "node_version=$(cat .node-version)" >> $GITHUB_OUTPUT
+          echo "yarn_version=$(jq -r '.engines.yarn' package.json)" >> $GITHUB_OUTPUT
+        working-directory: OpenSearch-Dashboards
+        shell: bash
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ steps.tool-versions.outputs.node_version }}
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Setup Opensearch Dashboards
+        run: |
+          npm uninstall -g yarn
+          echo "Installing yarn ${{ steps.tool-versions.outputs.yarn_version }}"
+          npm i -g yarn@${{ steps.tool-versions.outputs.yarn_version }}
+          yarn cache clean
+          yarn add sha.js
+        working-directory: OpenSearch-Dashboards
+        shell: bash
+
+      - name: Boodstrap Opensearch Dashboards
+        run: |
+          yarn osd bootstrap
+        working-directory: OpenSearch-Dashboards
+      
+      - name: Run Opensearch Dashboards with Gantt Chart Installed
+        run: |
+          nohup yarn start --no-base-path --no-watch | tee dashboard.log &
+        working-directory: OpenSearch-Dashboards
+
+      - name : Check If OpenSearch Dashboards Is Ready
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          if timeout 600 grep -q "bundles compiled successfully after" <(tail -n0 -f dashboard.log); then
+            echo "OpenSearch Dashboards compiled successfully."
+          else
+            echo "Timeout for 600 seconds reached. OpenSearch Dashboards did not finish compiling."
+            exit 1
+          fi
+        working-directory: OpenSearch-Dashboards
+
+      - name: Install Cypress
+        run: |
+          npx cypress install
+        shell: bash
+        working-directory: OpenSearch-Dashboards/plugins/dashboards-query-workbench
+
+      - name: Get Cypress version
+        id: cypress_version
+        run: |
+          echo "::set-output name=cypress_version::$(cat ./package.json | jq '.dependencies.cypress' | tr -d '"')"
+        working-directory: OpenSearch-Dashboards/plugins/dashboards-query-workbench
+
+      - name: Run Cypress tests
+        run: |
+          yarn cypress:run --browser chrome --headless --spec '.cypress/integration/${{ matrix.testgroups }}/*'
+        working-directory: OpenSearch-Dashboards/plugins/dashboards-query-workbench
+  
+      - name: Capture failure screenshots
+        uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: cypress-screenshots-${{ matrix.os }}
+          path: OpenSearch-Dashboards/plugins/dashboards-query-workbench/.cypress/screenshots
+  
+      - name: Capture test video
+        uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: cypress-videos-${{ matrix.os }}
+          path: OpenSearch-Dashboards/plugins/dashboards-query-workbench/.cypress/videos

--- a/.github/workflows/cypress-e2e-sql-workbench-test.yml
+++ b/.github/workflows/cypress-e2e-sql-workbench-test.yml
@@ -108,7 +108,7 @@ jobs:
           yarn osd bootstrap
         working-directory: OpenSearch-Dashboards
       
-      - name: Run Opensearch Dashboards with Gantt Chart Installed
+      - name: Run Opensearch Dashboards with Query Workbench Installed
         run: |
           nohup yarn start --no-base-path --no-watch | tee dashboard.log &
         working-directory: OpenSearch-Dashboards


### PR DESCRIPTION
### Description
Add E2E Cypress workflow for sql workbench
 
### Expected failure on Cypress Workflow
Reference to: https://github.com/opensearch-project/dashboards-query-workbench/actions/runs/7216048968/job/19661506355?pr=233#step:20:134
```
The response we got was:

Status: 406 - Not Acceptable
Headers: {
  "content-type": "application/json; charset=utf-8",
  "osd-name": "fv-az1269-175",
  "cache-control": "private, no-cache, no-store, must-revalidate",
  "vary": "accept-encoding",
  "content-encoding": "gzip",
  "date": "Fri, 15 Dec 2023 00:15:57 GMT",
  "connection": "keep-alive",
  "keep-alive": "timeout=120",
  "transfer-encoding": "chunked"
}
Body: {
  "error": "Content-Type header [application/x-www-form-urlencoded] is not supported",
  "status": 406
}
```
The above matches the expected failure on #232 

### Issues Resolved
* Relate #232 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).