### PR TITLE
Manual bump to 2.13 for workflows

### DIFF
--- a/.github/workflows/cypress-e2e-sql-workbench-test.yml
+++ b/.github/workflows/cypress-e2e-sql-workbench-test.yml
@@ -7,8 +7,8 @@ env:
   # avoid warnings like "tput: No value for $TERM and no -T specified"
   TERM: xterm
   OPENSEARCH_DASHBOARDS_VERSION: '2.x'
-  OPENSEARCH_VERSION: '2.12.0'
-  OPENSEARCH_PLUGIN_VERSION: '2.12.0.0'
+  OPENSEARCH_VERSION: '2.13.0'
+  OPENSEARCH_PLUGIN_VERSION: '2.13.0.0'
 
 jobs:
   tests:

--- a/.github/workflows/cypress-e2e-sql-workbench-test.yml
+++ b/.github/workflows/cypress-e2e-sql-workbench-test.yml
@@ -7,8 +7,6 @@ env:
   # avoid warnings like "tput: No value for $TERM and no -T specified"
   TERM: xterm
   OPENSEARCH_DASHBOARDS_VERSION: '2.x'
-  OPENSEARCH_VERSION: '2.13.0'
-  OPENSEARCH_PLUGIN_VERSION: '2.13.0.0'
 
 jobs:
   tests:
@@ -25,6 +23,17 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.jdk }}
+
+      - name: Checkout Branch
+        uses: actions/checkout@v3
+
+      - name: Set env
+        run: |
+          opensearch_version=$(node -p "require('./opensearch_dashboards.json').opensearchDashboardsVersion")
+          plugin_version=$(node -p "require('./opensearch_dashboards.json').version")
+          echo "OPENSEARCH_VERSION=$opensearch_version" >> $GITHUB_ENV
+          echo "OPENSEARCH_PLUGIN_VERSION=$plugin_version" >> $GITHUB_ENV
+        shell: bash
 
       - name: Download SQL artifact
         uses: suisei-cn/actions-download-file@v1.4.0

--- a/.github/workflows/ftr-e2e-sql-workbench-test.yml
+++ b/.github/workflows/ftr-e2e-sql-workbench-test.yml
@@ -7,8 +7,8 @@ env:
   # avoid warnings like "tput: No value for $TERM and no -T specified"
   TERM: xterm
   OPENSEARCH_DASHBOARDS_VERSION: '2.x'
-  OPENSEARCH_VERSION: '2.12.0'
-  OPENSEARCH_PLUGIN_VERSION: '2.12.0.0'
+  OPENSEARCH_VERSION: '2.13.0'
+  OPENSEARCH_PLUGIN_VERSION: '2.13.0.0'
 
 jobs:
   tests:

--- a/.github/workflows/ftr-e2e-sql-workbench-test.yml
+++ b/.github/workflows/ftr-e2e-sql-workbench-test.yml
@@ -7,8 +7,6 @@ env:
   # avoid warnings like "tput: No value for $TERM and no -T specified"
   TERM: xterm
   OPENSEARCH_DASHBOARDS_VERSION: '2.x'
-  OPENSEARCH_VERSION: '2.13.0'
-  OPENSEARCH_PLUGIN_VERSION: '2.13.0.0'
 
 jobs:
   tests:
@@ -25,6 +23,17 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.jdk }}
+
+      - name: Checkout Branch
+        uses: actions/checkout@v3
+
+      - name: Set env
+        run: |
+          opensearch_version=$(node -p "require('./opensearch_dashboards.json').opensearchDashboardsVersion")
+          plugin_version=$(node -p "require('./opensearch_dashboards.json').version")
+          echo "OPENSEARCH_VERSION=$opensearch_version" >> $GITHUB_ENV
+          echo "OPENSEARCH_PLUGIN_VERSION=$plugin_version" >> $GITHUB_ENV
+        shell: bash
 
       - name: Download SQL artifact
         uses: suisei-cn/actions-download-file@v1.4.0


### PR DESCRIPTION
### Description
FTR repos/functional tests are failing to run due to an issue with dashboards coming up healthy within 10 minutes. Not sure what's the issue. 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).