### PR TITLE
Moving Query Workbench to Dev Tools

### DIFF
--- a/common/utils/legacy_route_helper.tsx
+++ b/common/utils/legacy_route_helper.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const convertLegacyWorkbenchUrl = (location: Location) => {
+  // Update pathname to new structure
+  let pathname = location.pathname.replace(
+    'app/opensearch-query-workbench',
+    'app/dev_tools#/opensearch-query-workbench'
+  );
+
+  // If the pathname ends with '/', remove it before appending the hash
+  if (pathname.endsWith('/')) {
+    pathname = pathname.slice(0, -1);
+  }
+
+  // Adjust the hash part of the URL
+  let hash = location.hash.replace('#/', '/');
+
+  // If hash contains "accelerate" or any random text, handle it properly
+  if (hash.includes('accelerate/')) {
+    hash = hash.replace('#/', '/');
+  } else if (hash.startsWith('#/')) {
+    hash = hash.replace('#/', '/');
+  }
+
+  const finalUrl = `${pathname}${hash}`;
+
+  return finalUrl;
+};

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -4,6 +4,6 @@
   "opensearchDashboardsVersion": "3.0.0",
   "server": true,
   "ui": true,
-  "requiredPlugins": ["navigation", "opensearchDashboardsReact", "opensearchDashboardsUtils"],
+  "requiredPlugins": ["devTools", "navigation", "opensearchDashboardsReact", "opensearchDashboardsUtils"],
   "optionalPlugins": ["observabilityDashboards", "dataSource", "dataSourceManagement"]
 }

--- a/public/application.tsx
+++ b/public/application.tsx
@@ -29,7 +29,7 @@ export const renderApp = (
       dataSourceEnabled={!!dataSource}
       dataSourceManagement={dataSourceManagement}
       setActionMenu={setHeaderActionMenu}
-      dataSourceId={dataSourceId}
+      dataSourceMDSId={dataSourceId}
     />,
     element
   );

--- a/public/application.tsx
+++ b/public/application.tsx
@@ -17,7 +17,6 @@ export const renderApp = (
   { appBasePath, element, setHeaderActionMenu, dataSourceId }: AppMountParameters,
   dataSourceManagement: DataSourceManagementPluginSetup
 ) => {
-  console.log(dataSourceId);
   ReactDOM.render(
     <WorkbenchApp
       basename={appBasePath}

--- a/public/application.tsx
+++ b/public/application.tsx
@@ -14,9 +14,10 @@ import { AppPluginStartDependencies } from './types';
 export const renderApp = (
   { notifications, http, chrome, savedObjects }: CoreStart,
   { navigation, dataSource }: AppPluginStartDependencies,
-  { appBasePath, element, setHeaderActionMenu }: AppMountParameters,
+  { appBasePath, element, setHeaderActionMenu, dataSourceId }: AppMountParameters,
   dataSourceManagement: DataSourceManagementPluginSetup
 ) => {
+  console.log(dataSourceId);
   ReactDOM.render(
     <WorkbenchApp
       basename={appBasePath}
@@ -28,6 +29,7 @@ export const renderApp = (
       dataSourceEnabled={!!dataSource}
       dataSourceManagement={dataSourceManagement}
       setActionMenu={setHeaderActionMenu}
+      dataSourceId={dataSourceId}
     />,
     element
   );

--- a/public/application.tsx
+++ b/public/application.tsx
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { AppMountParameters, CoreStart } from '../../../src/core/public';

--- a/public/components/Main/main.tsx
+++ b/public/components/Main/main.tsx
@@ -110,7 +110,7 @@ interface MainProps {
   notifications: NotificationsStart;
   dataSourceEnabled: boolean;
   dataSourceManagement: DataSourceManagementPluginSetup;
-  dataSourceId: string;
+  dataSourceMDSId: string;
   setActionMenu: (menuMount: MountPoint | undefined) => void;
 }
 
@@ -287,7 +287,7 @@ export class Main extends React.Component<MainProps, MainState> {
       isCallOutVisible: false,
       cluster: 'Indexes',
       dataSourceOptions: [],
-      selectedMDSDataConnectionId: this.props.dataSourceId,
+      selectedMDSDataConnectionId: this.props.dataSourceMDSId,
       mdsClusterName: '',
       flintDataConnections: false,
     };
@@ -304,7 +304,7 @@ export class Main extends React.Component<MainProps, MainState> {
   fetchFlintDataSources = () => {
     fetchDataSources(
       this.httpClient,
-      this.props.dataSourceId,
+      this.props.dataSourceMDSId,
       this.props.urlDataSource,
       (dataOptions) => {
         if (dataOptions.length > 0) {
@@ -426,7 +426,7 @@ export class Main extends React.Component<MainProps, MainState> {
       const endpoint = '/api/sql_console/' + (_.isEqual(language, 'SQL') ? 'sqlquery' : 'pplquery');
       let query = {};
       if (this.props.dataSourceEnabled) {
-        query = { dataSourceMDSId: this.props.dataSourceId };
+        query = { dataSourceMDSId: this.props.dataSourceMDSId };
       }
       const responsePromise = Promise.all(
         queries.map((eachQuery: string) =>
@@ -561,7 +561,7 @@ export class Main extends React.Component<MainProps, MainState> {
               });
             }
           },
-          this.props.dataSourceId,
+          this.props.dataSourceMDSId,
           (errorDetails: string) => {
             this.setState({
               asyncLoading: false,
@@ -590,7 +590,7 @@ export class Main extends React.Component<MainProps, MainState> {
     if (queries.length > 0) {
       let query = {};
       if (this.props.dataSourceEnabled) {
-        query = { dataSourceMDSId: this.props.dataSourceId };
+        query = { dataSourceMDSId: this.props.dataSourceMDSId };
       }
       const endpoint =
         '/api/sql_console/' + (_.isEqual(language, 'SQL') ? 'translatesql' : 'translateppl');
@@ -642,7 +642,7 @@ export class Main extends React.Component<MainProps, MainState> {
     if (queries.length > 0) {
       let query = {};
       if (this.props.dataSourceEnabled) {
-        query = { dataSourceMDSId: this.props.dataSourceId };
+        query = { dataSourceMDSId: this.props.dataSourceMDSId };
       }
       Promise.all(
         queries.map((eachQuery: string) =>
@@ -679,7 +679,7 @@ export class Main extends React.Component<MainProps, MainState> {
     if (queries.length > 0) {
       let query = {};
       if (this.props.dataSourceEnabled) {
-        query = { dataSourceMDSId: this.props.dataSourceId };
+        query = { dataSourceMDSId: this.props.dataSourceMDSId };
       }
       const endpoint = '/api/sql_console/' + (_.isEqual(language, 'SQL') ? 'sqlquery' : 'pplquery');
       Promise.all(
@@ -717,7 +717,7 @@ export class Main extends React.Component<MainProps, MainState> {
     if (queries.length > 0) {
       let query = {};
       if (this.props.dataSourceEnabled) {
-        query = { dataSourceMDSId: this.props.dataSourceId };
+        query = { dataSourceMDSId: this.props.dataSourceMDSId };
       }
       const endpoint = '/api/sql_console/' + (_.isEqual(language, 'SQL') ? 'sqlcsv' : 'pplcsv');
       Promise.all(
@@ -755,7 +755,7 @@ export class Main extends React.Component<MainProps, MainState> {
     if (queries.length > 0) {
       let query = {};
       if (this.props.dataSourceEnabled) {
-        query = { dataSourceMDSId: this.props.dataSourceId };
+        query = { dataSourceMDSId: this.props.dataSourceMDSId };
       }
       const endpoint = '/api/sql_console/' + (_.isEqual(language, 'SQL') ? 'sqltext' : 'ppltext');
       Promise.all(
@@ -927,7 +927,7 @@ export class Main extends React.Component<MainProps, MainState> {
           openAccelerationFlyout={
             this.props.isAccelerationFlyoutOpen && !this.state.isAccelerationFlyoutOpened
           }
-          dataSourceMDSId={this.props.dataSourceId}
+          dataSourceMDSId={this.props.dataSourceMDSId}
           setIsAccelerationFlyoutOpened={this.setIsAccelerationFlyoutOpened}
         />
       );
@@ -1065,7 +1065,7 @@ export class Main extends React.Component<MainProps, MainState> {
                         onSelect={this.handleDataSelect}
                         urlDataSource={this.props.urlDataSource}
                         asyncLoading={this.state.asyncLoading}
-                        dataSourceMDSId={this.props.dataSourceId}
+                        dataSourceMDSId={this.props.dataSourceMDSId}
                       />
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>
@@ -1084,7 +1084,7 @@ export class Main extends React.Component<MainProps, MainState> {
                     updateSQLQueries={this.updateSQLQueries}
                     refreshTree={this.state.refreshTree}
                     dataSourceEnabled={this.props.dataSourceEnabled}
-                    dataSourceMDSId={this.props.dataSourceId}
+                    dataSourceMDSId={this.props.dataSourceMDSId}
                     clusterTab={this.state.cluster}
                     language={this.state.language}
                     updatePPLQueries={this.updatePPLQueries}

--- a/public/components/Main/main.tsx
+++ b/public/components/Main/main.tsx
@@ -42,6 +42,7 @@ import { AsyncApiResponse, AsyncQueryStatus } from '../../../common/types';
 import { executeAsyncQuery } from '../../../common/utils/async_query_helpers';
 import { fetchDataSources } from '../../../common/utils/fetch_datasources';
 import * as pluginManifest from '../../../opensearch_dashboards.json';
+import { coreRefs } from '../../framework/core_refs';
 import { MESSAGE_TAB_LABEL } from '../../utils/constants';
 import {
   Tree,
@@ -302,9 +303,29 @@ export class Main extends React.Component<MainProps, MainState> {
   }
 
   componentDidMount() {
+    if (coreRefs?.chrome?.navGroup.getNavGroupEnabled()) {
+      this.props.setBreadcrumbs([
+        {
+          text: 'Dev Tools',
+          href: '#/console',
+        },
+        {
+          text: 'Query Workbench',
+          href: '#/opensearch-query-workbench',
+        },
+      ]);
+    } else {
+      this.props.setBreadcrumbs([
+        {
+          text: 'Query Workbench',
+          href: '#',
+        },
+      ]);
+    }
+
     this.fetchFlintDataSources();
   }
-  
+
   fetchFlintDataSources = () => {
     fetchDataSources(
       this.httpClient,

--- a/public/components/Main/main.tsx
+++ b/public/components/Main/main.tsx
@@ -110,6 +110,7 @@ interface MainProps {
   notifications: NotificationsStart;
   dataSourceEnabled: boolean;
   dataSourceManagement: DataSourceManagementPluginSetup;
+  dataSourceId: string;
   setActionMenu: (menuMount: MountPoint | undefined) => void;
 }
 
@@ -286,7 +287,7 @@ export class Main extends React.Component<MainProps, MainState> {
       isCallOutVisible: false,
       cluster: 'Indexes',
       dataSourceOptions: [],
-      selectedMDSDataConnectionId: '',
+      selectedMDSDataConnectionId: this.props.dataSourceId,
       mdsClusterName: '',
       flintDataConnections: false,
     };
@@ -299,11 +300,11 @@ export class Main extends React.Component<MainProps, MainState> {
   componentDidMount() {
     this.fetchFlintDataSources();
   }
-
+  
   fetchFlintDataSources = () => {
     fetchDataSources(
       this.httpClient,
-      this.state.selectedMDSDataConnectionId,
+      this.props.dataSourceId,
       this.props.urlDataSource,
       (dataOptions) => {
         if (dataOptions.length > 0) {
@@ -425,7 +426,7 @@ export class Main extends React.Component<MainProps, MainState> {
       const endpoint = '/api/sql_console/' + (_.isEqual(language, 'SQL') ? 'sqlquery' : 'pplquery');
       let query = {};
       if (this.props.dataSourceEnabled) {
-        query = { dataSourceMDSId: this.state.selectedMDSDataConnectionId };
+        query = { dataSourceMDSId: this.props.dataSourceId };
       }
       const responsePromise = Promise.all(
         queries.map((eachQuery: string) =>
@@ -560,7 +561,7 @@ export class Main extends React.Component<MainProps, MainState> {
               });
             }
           },
-          this.state.selectedMDSDataConnectionId,
+          this.props.dataSourceId,
           (errorDetails: string) => {
             this.setState({
               asyncLoading: false,
@@ -589,7 +590,7 @@ export class Main extends React.Component<MainProps, MainState> {
     if (queries.length > 0) {
       let query = {};
       if (this.props.dataSourceEnabled) {
-        query = { dataSourceMDSId: this.state.selectedMDSDataConnectionId };
+        query = { dataSourceMDSId: this.props.dataSourceId };
       }
       const endpoint =
         '/api/sql_console/' + (_.isEqual(language, 'SQL') ? 'translatesql' : 'translateppl');
@@ -641,7 +642,7 @@ export class Main extends React.Component<MainProps, MainState> {
     if (queries.length > 0) {
       let query = {};
       if (this.props.dataSourceEnabled) {
-        query = { dataSourceMDSId: this.state.selectedMDSDataConnectionId };
+        query = { dataSourceMDSId: this.props.dataSourceId };
       }
       Promise.all(
         queries.map((eachQuery: string) =>
@@ -678,7 +679,7 @@ export class Main extends React.Component<MainProps, MainState> {
     if (queries.length > 0) {
       let query = {};
       if (this.props.dataSourceEnabled) {
-        query = { dataSourceMDSId: this.state.selectedMDSDataConnectionId };
+        query = { dataSourceMDSId: this.props.dataSourceId };
       }
       const endpoint = '/api/sql_console/' + (_.isEqual(language, 'SQL') ? 'sqlquery' : 'pplquery');
       Promise.all(
@@ -716,7 +717,7 @@ export class Main extends React.Component<MainProps, MainState> {
     if (queries.length > 0) {
       let query = {};
       if (this.props.dataSourceEnabled) {
-        query = { dataSourceMDSId: this.state.selectedMDSDataConnectionId };
+        query = { dataSourceMDSId: this.props.dataSourceId };
       }
       const endpoint = '/api/sql_console/' + (_.isEqual(language, 'SQL') ? 'sqlcsv' : 'pplcsv');
       Promise.all(
@@ -754,7 +755,7 @@ export class Main extends React.Component<MainProps, MainState> {
     if (queries.length > 0) {
       let query = {};
       if (this.props.dataSourceEnabled) {
-        query = { dataSourceMDSId: this.state.selectedMDSDataConnectionId };
+        query = { dataSourceMDSId: this.props.dataSourceId };
       }
       const endpoint = '/api/sql_console/' + (_.isEqual(language, 'SQL') ? 'sqltext' : 'ppltext');
       Promise.all(
@@ -926,7 +927,7 @@ export class Main extends React.Component<MainProps, MainState> {
           openAccelerationFlyout={
             this.props.isAccelerationFlyoutOpen && !this.state.isAccelerationFlyoutOpened
           }
-          dataSourceMDSId={this.state.selectedMDSDataConnectionId}
+          dataSourceMDSId={this.props.dataSourceId}
           setIsAccelerationFlyoutOpened={this.setIsAccelerationFlyoutOpened}
         />
       );
@@ -1064,7 +1065,7 @@ export class Main extends React.Component<MainProps, MainState> {
                         onSelect={this.handleDataSelect}
                         urlDataSource={this.props.urlDataSource}
                         asyncLoading={this.state.asyncLoading}
-                        dataSourceMDSId={this.state.selectedMDSDataConnectionId}
+                        dataSourceMDSId={this.props.dataSourceId}
                       />
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>
@@ -1083,7 +1084,7 @@ export class Main extends React.Component<MainProps, MainState> {
                     updateSQLQueries={this.updateSQLQueries}
                     refreshTree={this.state.refreshTree}
                     dataSourceEnabled={this.props.dataSourceEnabled}
-                    dataSourceMDSId={this.state.selectedMDSDataConnectionId}
+                    dataSourceMDSId={this.props.dataSourceId}
                     clusterTab={this.state.cluster}
                     language={this.state.language}
                     updatePPLQueries={this.updatePPLQueries}

--- a/public/components/Main/main.tsx
+++ b/public/components/Main/main.tsx
@@ -303,18 +303,7 @@ export class Main extends React.Component<MainProps, MainState> {
   }
 
   componentDidMount() {
-    if (coreRefs?.chrome?.navGroup.getNavGroupEnabled()) {
-      this.props.setBreadcrumbs([
-        {
-          text: 'Dev Tools',
-          href: '#/console',
-        },
-        {
-          text: 'Query Workbench',
-          href: '#/opensearch-query-workbench',
-        },
-      ]);
-    } else {
+    if (!coreRefs?.chrome?.navGroup.getNavGroupEnabled()) {
       this.props.setBreadcrumbs([
         {
           text: 'Query Workbench',

--- a/public/components/Main/main.tsx
+++ b/public/components/Main/main.tsx
@@ -288,7 +288,7 @@ export class Main extends React.Component<MainProps, MainState> {
       dataSourceOptions: [],
       selectedMDSDataConnectionId: '',
       mdsClusterName: '',
-      flintDataConnections: false
+      flintDataConnections: false,
     };
     this.httpClient = this.props.httpClient;
     this.updateSQLQueries = _.debounce(this.updateSQLQueries, 250).bind(this);
@@ -297,12 +297,6 @@ export class Main extends React.Component<MainProps, MainState> {
   }
 
   componentDidMount() {
-    this.props.setBreadcrumbs([
-      {
-        text: 'Query Workbench',
-        href: '#',
-      },
-    ]);
     this.fetchFlintDataSources();
   }
 
@@ -900,7 +894,7 @@ export class Main extends React.Component<MainProps, MainState> {
       mdsClusterName: clusterName,
       cluster: 'Indexes',
       selectedDatasource: [{ label: 'OpenSearch', key: '' }],
-      isAccelerationFlyoutOpened: false
+      isAccelerationFlyoutOpened: false,
     });
     this.fetchFlintDataSources();
   };
@@ -1018,7 +1012,7 @@ export class Main extends React.Component<MainProps, MainState> {
           />
         )}
         <EuiPage paddingSize="none">
-          <EuiPanel grow={true} style={{marginRight: '10px'}}>
+          <EuiPanel grow={true} style={{ marginRight: '10px' }}>
             <EuiPageSideBar
               style={{
                 maxWidth: '400px',
@@ -1026,10 +1020,12 @@ export class Main extends React.Component<MainProps, MainState> {
                 height: 'calc(100vh - 254px)',
               }}
             >
-              <EuiTitle size='xs'>
-                  <p><b>{this.state.mdsClusterName}</b></p>
-                </EuiTitle>
-                <EuiSpacer size='s'/>
+              <EuiTitle size="xs">
+                <p>
+                  <b>{this.state.mdsClusterName}</b>
+                </p>
+              </EuiTitle>
+              <EuiSpacer size="s" />
               {this.state.flintDataConnections && (
                 <EuiFlexGroup direction="row" gutterSize="s">
                   <EuiFlexItem grow={false}>

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -24,6 +24,7 @@ interface WorkbenchAppDeps {
   savedObjects: CoreStart['savedObjects'];
   dataSourceEnabled: boolean;
   dataSourceManagement: DataSourceManagementPluginSetup;
+  dataSourceId: string;
   setActionMenu: (menuMount: MountPoint | undefined) => void;
 }
 
@@ -36,6 +37,7 @@ export const WorkbenchApp = ({
   savedObjects,
   dataSourceEnabled,
   dataSourceManagement,
+  dataSourceId,
   setActionMenu,
 }: WorkbenchAppDeps) => {
   return (
@@ -59,6 +61,7 @@ export const WorkbenchApp = ({
                       savedObjects={savedObjects}
                       dataSourceEnabled={dataSourceEnabled}
                       dataSourceManagement={dataSourceManagement}
+                      dataSourceId={dataSourceId}
                       setActionMenu={setActionMenu}
                     />
                   )}
@@ -77,6 +80,7 @@ export const WorkbenchApp = ({
                       savedObjects={savedObjects}
                       dataSourceEnabled={dataSourceEnabled}
                       dataSourceManagement={dataSourceManagement}
+                      dataSourceId={dataSourceId}
                       setActionMenu={setActionMenu}
                     />
                   )}
@@ -95,6 +99,7 @@ export const WorkbenchApp = ({
                       savedObjects={savedObjects}
                       dataSourceEnabled={dataSourceEnabled}
                       dataSourceManagement={dataSourceManagement}
+                      dataSourceId={dataSourceId}
                       setActionMenu={setActionMenu}
                     />
                   )}

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -13,6 +13,7 @@ import { CoreStart, MountPoint } from '../../../../src/core/public';
 import { DataSourceManagementPluginSetup } from '../../../../src/plugins/data_source_management/public';
 import { NavigationPublicPluginStart } from '../../../../src/plugins/navigation/public';
 
+import { coreRefs } from '../framework/core_refs';
 import { Main } from './Main';
 
 interface WorkbenchAppDeps {
@@ -40,6 +41,9 @@ export const WorkbenchApp = ({
   dataSourceMDSId: dataSourceId,
   setActionMenu,
 }: WorkbenchAppDeps) => {
+  const isNavGroupEnabled = coreRefs?.chrome?.navGroup.getNavGroupEnabled();
+  const basePath = isNavGroupEnabled ? 'opensearch-query-workbench' : '';
+
   return (
     <HashRouter>
       <I18nProvider>
@@ -49,7 +53,7 @@ export const WorkbenchApp = ({
               <Switch>
                 <Route
                   exact
-                  path="/opensearch-query-workbench"
+                  path={`/${basePath}`}
                   render={(props) => (
                     <Main
                       httpClient={http}
@@ -68,7 +72,7 @@ export const WorkbenchApp = ({
                 />
                 <Route
                   exact
-                  path="/opensearch-query-workbench/:dataSource"
+                  path={`/${basePath}/:dataSource`}
                   render={(props) => (
                     <Main
                       httpClient={http}
@@ -87,7 +91,7 @@ export const WorkbenchApp = ({
                 />
                 <Route
                   exact
-                  path="/opensearch-query-workbench/accelerate/:dataSource"
+                  path={`/${basePath}/accelerate/:dataSource`}
                   render={(props) => (
                     <Main
                       httpClient={http}

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -24,7 +24,7 @@ interface WorkbenchAppDeps {
   savedObjects: CoreStart['savedObjects'];
   dataSourceEnabled: boolean;
   dataSourceManagement: DataSourceManagementPluginSetup;
-  dataSourceId: string;
+  dataSourceMDSId: string;
   setActionMenu: (menuMount: MountPoint | undefined) => void;
 }
 
@@ -37,7 +37,7 @@ export const WorkbenchApp = ({
   savedObjects,
   dataSourceEnabled,
   dataSourceManagement,
-  dataSourceId,
+  dataSourceMDSId: dataSourceId,
   setActionMenu,
 }: WorkbenchAppDeps) => {
   return (
@@ -61,7 +61,7 @@ export const WorkbenchApp = ({
                       savedObjects={savedObjects}
                       dataSourceEnabled={dataSourceEnabled}
                       dataSourceManagement={dataSourceManagement}
-                      dataSourceId={dataSourceId}
+                      dataSourceMDSId={dataSourceId}
                       setActionMenu={setActionMenu}
                     />
                   )}
@@ -80,7 +80,7 @@ export const WorkbenchApp = ({
                       savedObjects={savedObjects}
                       dataSourceEnabled={dataSourceEnabled}
                       dataSourceManagement={dataSourceManagement}
-                      dataSourceId={dataSourceId}
+                      dataSourceMDSId={dataSourceId}
                       setActionMenu={setActionMenu}
                     />
                   )}
@@ -99,7 +99,7 @@ export const WorkbenchApp = ({
                       savedObjects={savedObjects}
                       dataSourceEnabled={dataSourceEnabled}
                       dataSourceManagement={dataSourceManagement}
-                      dataSourceId={dataSourceId}
+                      dataSourceMDSId={dataSourceId}
                       setActionMenu={setActionMenu}
                     />
                   )}

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -49,7 +49,7 @@ export const WorkbenchApp = ({
               <Switch>
                 <Route
                   exact
-                  path="/"
+                  path="/opensearch-query-workbench"
                   render={(props) => (
                     <Main
                       httpClient={http}
@@ -68,7 +68,7 @@ export const WorkbenchApp = ({
                 />
                 <Route
                   exact
-                  path="/:dataSource"
+                  path="/opensearch-query-workbench/:dataSource"
                   render={(props) => (
                     <Main
                       httpClient={http}
@@ -87,7 +87,7 @@ export const WorkbenchApp = ({
                 />
                 <Route
                   exact
-                  path="/accelerate/:dataSource"
+                  path="/opensearch-query-workbench/accelerate/:dataSource"
                   render={(props) => (
                     <Main
                       httpClient={http}

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -11,6 +11,7 @@ import {
 import { DataSourceManagementPluginSetup } from '../../../src/plugins/data_source_management/public';
 import { DevToolsSetup } from '../../../src/plugins/dev_tools/public';
 import { PLUGIN_NAME } from '../common/constants';
+import { convertLegacyWorkbenchUrl } from '../common/utils/legacy_route_helper';
 import { registerObservabilityDependencies } from './dependencies/register_observability_dependencies';
 import { coreRefs } from './framework/core_refs';
 import { AppPluginStartDependencies, WorkbenchPluginSetup, WorkbenchPluginStart } from './types';
@@ -43,10 +44,15 @@ export class WorkbenchPlugin implements Plugin<WorkbenchPluginSetup, WorkbenchPl
           coreStart,
           depsStart as AppPluginStartDependencies,
           params,
-          dataSourceManagement,
+          dataSourceManagement
         );
       },
     });
+
+    // redirect legacy workbench URL to current URL under dev-tools
+    if (window.location.pathname.includes('app/opensearch-query-workbench')) {
+      window.location.assign(convertLegacyWorkbenchUrl(window.location));
+    }
 
     // Return methods that should be available to other plugins
     return {};

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -43,7 +43,7 @@ export class WorkbenchPlugin implements Plugin<WorkbenchPluginSetup, WorkbenchPl
           coreStart,
           depsStart as AppPluginStartDependencies,
           params,
-          dataSourceManagement
+          dataSourceManagement,
         );
       },
     });

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -29,29 +29,57 @@ export class WorkbenchPlugin implements Plugin<WorkbenchPluginSetup, WorkbenchPl
     core: CoreSetup,
     { dataSource, dataSourceManagement, devTools }: WorkbenchPluginSetupDependencies
   ): WorkbenchPluginSetup {
-    devTools.register({
-      id: 'opensearch-query-workbench',
-      title: PLUGIN_NAME,
-      enableRouting: true,
-      order: 2,
-      async mount(params: AppMountParameters) {
-        // Load application bundle
-        const { renderApp } = await import('./application');
-        // Get start services as specified in opensearch_dashboards.json
-        const [coreStart, depsStart] = await core.getStartServices();
-        // Render the application
-        return renderApp(
-          coreStart,
-          depsStart as AppPluginStartDependencies,
-          params,
-          dataSourceManagement
-        );
-      },
-    });
+    const isNavGroupEnabled = core.chrome.navGroup.getNavGroupEnabled();
 
-    // redirect legacy workbench URL to current URL under dev-tools
-    if (window.location.pathname.includes('app/opensearch-query-workbench')) {
-      window.location.assign(convertLegacyWorkbenchUrl(window.location));
+    if (isNavGroupEnabled) {
+      devTools.register({
+        id: 'opensearch-query-workbench',
+        title: PLUGIN_NAME,
+        enableRouting: true,
+        order: 2,
+        async mount(params: AppMountParameters) {
+          // Load application bundle
+          const { renderApp } = await import('./application');
+          // Get start services as specified in opensearch_dashboards.json
+          const [coreStart, depsStart] = await core.getStartServices();
+          // Render the application
+          return renderApp(
+            coreStart,
+            depsStart as AppPluginStartDependencies,
+            params,
+            dataSourceManagement
+          );
+        },
+      });
+
+      // redirect legacy workbench URL to current URL under dev-tools
+      if (window.location.pathname.includes('app/opensearch-query-workbench')) {
+        window.location.assign(convertLegacyWorkbenchUrl(window.location));
+      }
+    } else {
+      core.application.register({
+        id: 'opensearch-query-workbench',
+        title: PLUGIN_NAME,
+        category: {
+          id: 'opensearch',
+          label: 'OpenSearch Plugins',
+          order: 2000,
+        },
+        order: 1000,
+        async mount(params: AppMountParameters) {
+          // Load application bundle
+          const { renderApp } = await import('./application');
+          // Get start services as specified in opensearch_dashboards.json
+          const [coreStart, depsStart] = await core.getStartServices();
+          // Render the application
+          return renderApp(
+            coreStart,
+            depsStart as AppPluginStartDependencies,
+            params,
+            dataSourceManagement
+          );
+        },
+      });
     }
 
     // Return methods that should be available to other plugins

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -4,39 +4,47 @@
  */
 
 import { AppMountParameters, CoreSetup, CoreStart, Plugin } from '../../../src/core/public';
-import { DataSourcePluginSetup, DataSourcePluginStart } from '../../../src/plugins/data_source/public';
+import {
+  DataSourcePluginSetup,
+  DataSourcePluginStart,
+} from '../../../src/plugins/data_source/public';
 import { DataSourceManagementPluginSetup } from '../../../src/plugins/data_source_management/public';
+import { DevToolsSetup } from '../../../src/plugins/dev_tools/public';
 import { PLUGIN_NAME } from '../common/constants';
 import { registerObservabilityDependencies } from './dependencies/register_observability_dependencies';
 import { coreRefs } from './framework/core_refs';
 import { AppPluginStartDependencies, WorkbenchPluginSetup, WorkbenchPluginStart } from './types';
 export interface WorkbenchPluginSetupDependencies {
   dataSource: DataSourcePluginSetup;
-  dataSourceManagement: DataSourceManagementPluginSetup
+  dataSourceManagement: DataSourceManagementPluginSetup;
+  devTools: DevToolsSetup;
 }
 
 export interface WorkbenchPluginStartDependencies {
   dataSource: DataSourcePluginStart;
 }
 export class WorkbenchPlugin implements Plugin<WorkbenchPluginSetup, WorkbenchPluginStart> {
-  public setup(core: CoreSetup, {dataSource, dataSourceManagement} : WorkbenchPluginSetupDependencies): WorkbenchPluginSetup {
-    // Register an application into the side navigation menu
-    core.application.register({
+  public setup(
+    core: CoreSetup,
+    { dataSource, dataSourceManagement, devTools }: WorkbenchPluginSetupDependencies
+  ): WorkbenchPluginSetup {
+    devTools.register({
       id: 'opensearch-query-workbench',
       title: PLUGIN_NAME,
-      category: {
-        id: 'opensearch',
-        label: 'OpenSearch Plugins',
-        order: 2000,
-      },
-      order: 1000,
+      enableRouting: true,
+      order: 2,
       async mount(params: AppMountParameters) {
         // Load application bundle
         const { renderApp } = await import('./application');
         // Get start services as specified in opensearch_dashboards.json
         const [coreStart, depsStart] = await core.getStartServices();
         // Render the application
-        return renderApp(coreStart, depsStart as AppPluginStartDependencies, params, dataSourceManagement);
+        return renderApp(
+          coreStart,
+          depsStart as AppPluginStartDependencies,
+          params,
+          dataSourceManagement
+        );
       },
     });
 


### PR DESCRIPTION
### Description
<img width="269" alt="Screenshot 2024-07-11 at 5 26 49 PM" src="https://github.com/user-attachments/assets/f9405ddd-acd1-4374-b11a-7a1ee13e785d">

This change migrates query workbench to dev tools for the navigation changes planned for 2.16. The way the selectedMDSDataConnectionId was passed needed to be updated to allow dev tools to correctly find data sources.

Working with MDS:

https://github.com/user-attachments/assets/d0e02549-c299-40de-b4fd-8de5b15f4d07


Working with Flint:
[FlintTest.mov.zip](https://github.com/user-attachments/files/16185668/FlintTest.mov.zip)


There is an existing issue I outlined in https://github.com/opensearch-project/dashboards-query-workbench/issues/348. But testing with Flint(using dashboards-observability prior to the https://github.com/opensearch-project/dashboards-observability/commit/19d68b2d443458c3fdb1bd0fe035bf823111015b commit) seems to keep all functionality working correctly.

### Issues Resolved

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).