### PR TITLE
[navigation] Add default render path when there is basePath

### DIFF
--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -109,18 +109,24 @@ export const WorkbenchApp = ({
                   )}
                 />
                 {basePath && (
-                  <Main
-                    httpClient={http}
-                    {...props}
-                    setBreadcrumbs={chrome.setBreadcrumbs}
-                    isAccelerationFlyoutOpen={false}
-                    urlDataSource=""
-                    notifications={notifications}
-                    savedObjects={savedObjects}
-                    dataSourceEnabled={dataSourceEnabled}
-                    dataSourceManagement={dataSourceManagement}
-                    dataSourceMDSId={dataSourceId}
-                    setActionMenu={setActionMenu}
+                  <Route
+                    exact
+                    path="/"
+                    render={(props) => (
+                      <Main
+                        httpClient={http}
+                        {...props}
+                        setBreadcrumbs={chrome.setBreadcrumbs}
+                        isAccelerationFlyoutOpen={false}
+                        urlDataSource=""
+                        notifications={notifications}
+                        savedObjects={savedObjects}
+                        dataSourceEnabled={dataSourceEnabled}
+                        dataSourceManagement={dataSourceManagement}
+                        dataSourceMDSId={dataSourceId}
+                        setActionMenu={setActionMenu}
+                      />
+                    )}
                   />
                 )}
               </Switch>

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -108,6 +108,21 @@ export const WorkbenchApp = ({
                     />
                   )}
                 />
+                {basePath && (
+                  <Main
+                    httpClient={http}
+                    {...props}
+                    setBreadcrumbs={chrome.setBreadcrumbs}
+                    isAccelerationFlyoutOpen={false}
+                    urlDataSource=""
+                    notifications={notifications}
+                    savedObjects={savedObjects}
+                    dataSourceEnabled={dataSourceEnabled}
+                    dataSourceManagement={dataSourceManagement}
+                    dataSourceMDSId={dataSourceId}
+                    setActionMenu={setActionMenu}
+                  />
+                )}
               </Switch>
             </EuiPageBody>
           </EuiPage>


### PR DESCRIPTION
### Description

As we will make dev tools as a full page modal when new nav toggle is turned on, we will use `MemoryRouter` to replace `HashRouter` in our page to avoid modifying the hosted page' hash. And this change will impact search relevance functionality.

And this PR adds a default path when there is no '/' route.

For more details please take a look on the comment: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7938#discussion_r1738383931.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).