### PR TITLE
[Bug] Fix url redirection, add default render path

### DIFF
--- a/public/components/Main/main.tsx
+++ b/public/components/Main/main.tsx
@@ -291,7 +291,7 @@ export class Main extends React.Component<MainProps, MainState> {
       refreshTree: false,
       isAccelerationFlyoutOpened: false,
       isCallOutVisible: false,
-      cluster: props.urlDataSource?'Data source Connections':'Indexes',
+      cluster: props.urlDataSource ? 'Data source Connections' : 'Indexes',
       dataSourceOptions: [],
       selectedMDSDataConnectionId: this.props.dataSourceMDSId,
       mdsClusterName: '',

--- a/public/components/Main/main.tsx
+++ b/public/components/Main/main.tsx
@@ -291,7 +291,7 @@ export class Main extends React.Component<MainProps, MainState> {
       refreshTree: false,
       isAccelerationFlyoutOpened: false,
       isCallOutVisible: false,
-      cluster: 'Indexes',
+      cluster: props.urlDataSource?'Data source Connections':'Indexes',
       dataSourceOptions: [],
       selectedMDSDataConnectionId: this.props.dataSourceMDSId,
       mdsClusterName: '',

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -108,7 +108,7 @@ export const WorkbenchApp = ({
                     />
                   )}
                 />
-                {basePath && (
+                {isNavGroupEnabled && (
                   <Route
                     exact
                     path="/"

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -42,7 +42,7 @@ export const WorkbenchApp = ({
   setActionMenu,
 }: WorkbenchAppDeps) => {
   const isNavGroupEnabled = coreRefs?.chrome?.navGroup.getNavGroupEnabled();
-  const basePath = isNavGroupEnabled ? 'opensearch-query-workbench' : '';
+  const basePath = isNavGroupEnabled ? '/opensearch-query-workbench' : '';
 
   return (
     <HashRouter>
@@ -53,7 +53,7 @@ export const WorkbenchApp = ({
               <Switch>
                 <Route
                   exact
-                  path={`/${basePath}`}
+                  path={isNavGroupEnabled ? basePath : `/${basePath}`}
                   render={(props) => (
                     <Main
                       httpClient={http}
@@ -72,7 +72,7 @@ export const WorkbenchApp = ({
                 />
                 <Route
                   exact
-                  path={`/${basePath}/:dataSource`}
+                  path={`${basePath}/:dataSource`}
                   render={(props) => (
                     <Main
                       httpClient={http}
@@ -91,7 +91,7 @@ export const WorkbenchApp = ({
                 />
                 <Route
                   exact
-                  path={`/${basePath}/accelerate/:dataSource`}
+                  path={`${basePath}/accelerate/:dataSource`}
                   render={(props) => (
                     <Main
                       httpClient={http}
@@ -108,6 +108,27 @@ export const WorkbenchApp = ({
                     />
                   )}
                 />
+                {basePath && (
+                  <Route
+                    exact
+                    path="/"
+                    render={(props) => (
+                      <Main
+                        httpClient={http}
+                        {...props}
+                        setBreadcrumbs={chrome.setBreadcrumbs}
+                        isAccelerationFlyoutOpen={false}
+                        urlDataSource=""
+                        notifications={notifications}
+                        savedObjects={savedObjects}
+                        dataSourceEnabled={dataSourceEnabled}
+                        dataSourceManagement={dataSourceManagement}
+                        dataSourceMDSId={dataSourceId}
+                        setActionMenu={setActionMenu}
+                      />
+                    )}
+                  />
+                )}
               </Switch>
             </EuiPageBody>
           </EuiPage>

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -53,7 +53,7 @@ export const WorkbenchApp = ({
               <Switch>
                 <Route
                   exact
-                  path={isNavGroupEnabled ? basePath : `/${basePath}`}
+                  path={isNavGroupEnabled ? [`${basePath}`, `/`] : `/${basePath}`}
                   render={(props) => (
                     <Main
                       httpClient={http}
@@ -108,27 +108,6 @@ export const WorkbenchApp = ({
                     />
                   )}
                 />
-                {isNavGroupEnabled && (
-                  <Route
-                    exact
-                    path="/"
-                    render={(props) => (
-                      <Main
-                        httpClient={http}
-                        {...props}
-                        setBreadcrumbs={chrome.setBreadcrumbs}
-                        isAccelerationFlyoutOpen={false}
-                        urlDataSource=""
-                        notifications={notifications}
-                        savedObjects={savedObjects}
-                        dataSourceEnabled={dataSourceEnabled}
-                        dataSourceManagement={dataSourceManagement}
-                        dataSourceMDSId={dataSourceId}
-                        setActionMenu={setActionMenu}
-                      />
-                    )}
-                  />
-                )}
               </Switch>
             </EuiPageBody>
           </EuiPage>


### PR DESCRIPTION
### Description
1. Fix url redirection
2. Add default render path when there is basePath
    closing : https://github.com/opensearch-project/dashboards-query-workbench/pull/381
(Support for dev tools under modal pop out)
As we will make dev tools as a full page modal when new nav toggle is turned on, we will use MemoryRouter to replace HashRouter in our page to avoid modifying the hosted page' hash. And this change will impact search relevance functionality.
And this PR adds a default path when there is no '/' route.
For more details please take a look on the comment: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7938#discussion_r1738383931.

Tested url paths:
path={`/${basePath}/:dataSource`}
path={`/${basePath}/accelerate/:dataSource`}
path="/"
path={`/${basePath}`}

Old Navigation:

https://github.com/user-attachments/assets/128c154d-e4be-4ab8-ba19-3f974306b010



New Navigation:

https://github.com/user-attachments/assets/5b225238-e4e9-4181-a020-58b89981261a



New Navigation + https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7938 modal applied.

https://github.com/user-attachments/assets/592fd5ff-78c7-4e3f-91f5-349fe3aaf14a


### Issues Resolved
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).