### PR TITLE
update CIs to install job-scheduler plugin

### DIFF
--- a/.github/workflows/cypress-e2e-sql-workbench-test.yml
+++ b/.github/workflows/cypress-e2e-sql-workbench-test.yml
@@ -6,9 +6,9 @@ env:
   CI: 1
   # avoid warnings like "tput: No value for $TERM and no -T specified"
   TERM: xterm
-  OPENSEARCH_DASHBOARDS_VERSION: 'main'
-  OPENSEARCH_VERSION: '3.0.0-alpha1'
-  OPENSEARCH_PLUGIN_VERSION: '3.0.0.0-alpha1'
+  OPENSEARCH_DASHBOARDS_VERSION: "main"
+  OPENSEARCH_VERSION: "3.0.0-alpha1"
+  OPENSEARCH_PLUGIN_VERSION: "3.0.0.0-alpha1"
 
 jobs:
   tests:
@@ -16,8 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
-        jdk: [ 21 ]
+        os: [ubuntu-latest]
+        jdk: [21]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -33,38 +33,50 @@ jobs:
           target: plugin-artifacts/
           filename: sql.zip
 
+      - name: Download Job Scheduler artifact
+        uses: suisei-cn/actions-download-file@v1.4.0
+        with:
+          url: https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-job-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip
+          target: plugin-artifacts/
+          filename: opensearch-job-scheduler.zip
+
       - name: Download OpenSearch
         uses: peternied/download-file@v2
         with:
           url: https://artifacts.opensearch.org/snapshots/core/opensearch/${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/opensearch-min-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT-linux-x64-latest.tar.gz
-  
+
       - name: Extract OpenSearch
         run: |
           tar -xzf opensearch-*.tar.gz
           rm -f opensearch-*.tar.gz
         shell: bash
-      
+
+      - name: Install job scheduler plugin
+        run: |
+          /bin/bash -c "yes | ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/bin/opensearch-plugin install file:$(pwd)/plugin-artifacts/opensearch-job-scheduler.zip"
+        shell: bash
+
       - name: Install SQL plugin
         run: |
           /bin/bash -c "yes | ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/bin/opensearch-plugin install file:$(pwd)/plugin-artifacts/sql.zip"
         shell: bash
-    
+
       - name: Run OpenSearch
         run: |
           /bin/bash -c "./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/bin/opensearch &"
           sleep 30
         shell: bash
-    
+
       - name: Check OpenSearch Running on Linux
         if: ${{ runner.os != 'Windows'}}
         run: curl http://localhost:9200/
         shell: bash
-      
+
       - name: Show OpenSearch Logs
         if: always()
         run: cat ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/logs/opensearch.log
         shell: bash
-      
+
       - name: Checkout OpenSearch Dashboards
         uses: actions/checkout@v2
         with:
@@ -79,7 +91,7 @@ jobs:
       - name: Checkout Query Workbench in OpenSearch Dashboards Plugins Dir
         uses: actions/checkout@v2
         with:
-            path: OpenSearch-Dashboards/plugins/dashboards-query-workbench
+          path: OpenSearch-Dashboards/plugins/dashboards-query-workbench
 
       - id: tool-versions
         run: |
@@ -91,7 +103,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ steps.tool-versions.outputs.node_version }}
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
 
       - name: Setup Opensearch Dashboards
         run: |
@@ -107,13 +119,13 @@ jobs:
         run: |
           yarn osd bootstrap --single-version=loose
         working-directory: OpenSearch-Dashboards
-      
+
       - name: Run Opensearch Dashboards with Query Workbench Installed
         run: |
           nohup yarn start --no-base-path --no-watch | tee dashboard.log &
         working-directory: OpenSearch-Dashboards
 
-      - name : Check If OpenSearch Dashboards Is Ready
+      - name: Check If OpenSearch Dashboards Is Ready
         if: ${{ runner.os == 'Linux' }}
         run: |
           if timeout 600 grep -q "bundles compiled successfully after" <(tail -n0 -f dashboard.log); then
@@ -140,14 +152,14 @@ jobs:
         run: |
           yarn cypress:run --browser chrome --headless --spec '.cypress/integration/${{ matrix.testgroups }}/*'
         working-directory: OpenSearch-Dashboards/plugins/dashboards-query-workbench
-  
+
       - name: Capture failure screenshots
         uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-screenshots-${{ matrix.os }}
           path: OpenSearch-Dashboards/plugins/dashboards-query-workbench/.cypress/screenshots
-  
+
       - name: Capture test video
         uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/ftr-e2e-sql-workbench-test.yml
+++ b/.github/workflows/ftr-e2e-sql-workbench-test.yml
@@ -51,6 +51,11 @@ jobs:
           rm -f opensearch-*.tar.gz
         shell: bash
 
+      - name: Install job scheduler plugin
+        run: |
+          /bin/bash -c "yes | ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/bin/opensearch-plugin install file:$(pwd)/plugin-artifacts/opensearch-job-scheduler.zip"
+        shell: bash
+
       - name: Install SQL plugin
         run: |
           /bin/bash -c "yes | ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/bin/opensearch-plugin install file:$(pwd)/plugin-artifacts/sql.zip"

--- a/.github/workflows/ftr-e2e-sql-workbench-test.yml
+++ b/.github/workflows/ftr-e2e-sql-workbench-test.yml
@@ -6,9 +6,9 @@ env:
   CI: 1
   # avoid warnings like "tput: No value for $TERM and no -T specified"
   TERM: xterm
-  OPENSEARCH_DASHBOARDS_VERSION: 'main'
-  OPENSEARCH_VERSION: '3.0.0-alpha1'
-  OPENSEARCH_PLUGIN_VERSION: '3.0.0.0-alpha1'
+  OPENSEARCH_DASHBOARDS_VERSION: "main"
+  OPENSEARCH_VERSION: "3.0.0-alpha1"
+  OPENSEARCH_PLUGIN_VERSION: "3.0.0.0-alpha1"
 
 jobs:
   tests:
@@ -16,8 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
-        jdk: [ 21 ]
+        os: [ubuntu-latest]
+        jdk: [21]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -33,38 +33,45 @@ jobs:
           target: plugin-artifacts/
           filename: sql.zip
 
+      - name: Download Job Scheduler artifact
+        uses: suisei-cn/actions-download-file@v1.4.0
+        with:
+          url: https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-job-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip
+          target: plugin-artifacts/
+          filename: opensearch-job-scheduler.zip
+
       - name: Download OpenSearch
         uses: peternied/download-file@v2
         with:
           url: https://artifacts.opensearch.org/snapshots/core/opensearch/${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/opensearch-min-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT-linux-x64-latest.tar.gz
-  
+
       - name: Extract OpenSearch
         run: |
           tar -xzf opensearch-*.tar.gz
           rm -f opensearch-*.tar.gz
         shell: bash
-      
+
       - name: Install SQL plugin
         run: |
           /bin/bash -c "yes | ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/bin/opensearch-plugin install file:$(pwd)/plugin-artifacts/sql.zip"
         shell: bash
-    
+
       - name: Run OpenSearch
         run: |
           /bin/bash -c "./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/bin/opensearch &"
           sleep 30
         shell: bash
-    
+
       - name: Check OpenSearch Running on Linux
         if: ${{ runner.os != 'Windows'}}
         run: curl http://localhost:9200/
         shell: bash
-      
+
       - name: Show OpenSearch Logs
         if: always()
         run: cat ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/logs/opensearch.log
         shell: bash
-      
+
       - name: Checkout OpenSearch Dashboards
         uses: actions/checkout@v2
         with:
@@ -79,7 +86,7 @@ jobs:
       - name: Checkout Query Workbench in OpenSearch Dashboards Plugins Dir
         uses: actions/checkout@v2
         with:
-            path: OpenSearch-Dashboards/plugins/dashboards-query-workbench
+          path: OpenSearch-Dashboards/plugins/dashboards-query-workbench
 
       - id: tool-versions
         run: |
@@ -91,7 +98,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ steps.tool-versions.outputs.node_version }}
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
 
       - name: Setup Opensearch Dashboards
         run: |
@@ -107,13 +114,13 @@ jobs:
         run: |
           yarn osd bootstrap --single-version=loose
         working-directory: OpenSearch-Dashboards
-      
+
       - name: Run Opensearch Dashboards with Query Workbench Installed
         run: |
           nohup yarn start --no-base-path --no-watch | tee dashboard.log &
         working-directory: OpenSearch-Dashboards
 
-      - name : Check If OpenSearch Dashboards Is Ready
+      - name: Check If OpenSearch Dashboards Is Ready
         if: ${{ runner.os == 'Linux' }}
         run: |
           if timeout 600 grep -q "bundles compiled successfully after" <(tail -n0 -f dashboard.log); then


### PR DESCRIPTION
### Description
Add job scheduler to workbench CI, SQL plugin recently added this as an dependency leading the observability CI failing waiting for Job scheduler plugin. Related upstream PR: https://github.com/opensearch-project/sql/pull/2834
 
### Issues Resolved
https://github.com/opensearch-project/dashboards-query-workbench/issues/97
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).