### PR TITLE
[Bug] Fix query splitting with quoted semicolons

### DIFF
--- a/public/utils/utils.test.ts
+++ b/public/utils/utils.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  getQueries
+} from './utils';
+
+describe('getQueries', () => {
+  it('should return a simple query without issues.', () => {
+    expect(getQueries("select 1")).toEqual(["select 1"]);
+  });
+  it('should split queries by semicolons', () => {
+    expect(getQueries("select 1;select 2;select 3"))
+      .toEqual(["select 1", "select 2", "select 3"]);
+  });
+  it('should not choke on opening or closing semicolons', () => {
+    expect(getQueries(";;;select 1;;")).toEqual(["select 1"]);
+  });
+  it('should not split on quoted semi-colons', () => {
+    expect(getQueries("select * from x where y = '1;2' or y = '3;4'")).toEqual(
+      ["select * from x where y = '1;2' or y = '3;4'"]);
+  });
+  it('should not split on quoted escaped semi-colons', () => {
+    expect(getQueries("select * from x where y = '1\\;2\\;';select * from x where y = '3'")).toEqual(
+      ["select * from x where y = '1;2;'", "select * from x where y = '3'"]);
+  });
+  it('should not get tripped up by nested quotes and escaped semicolons in quotes, either', () => {
+    expect(getQueries("select * from x where y = '1\\\\'\\\\';\\;2';select * from x where y = '\\\"3;\\;\\\\'\\\\'4;'")).toEqual(
+      ["select * from x where y = '1\\'\\';;2'", "select * from x where y = '\"3;;\\'\\'4;'"]);
+  });
+});
+


### PR DESCRIPTION
### Description
The Query Workbench would terminate queries with semicolons, even if the semicolons were inside quoted strings.
For example, `select * from x where y = '1;2'` would POST to the server `select * from x where y = '1`.

This change makes the query parsing a bit more sophisticated, and attempts to handle quoting properly.
 
### Issues Resolved
https://github.com/opensearch-project/dashboards-query-workbench/issues/243
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.  (Not Applicable)
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).