### PR TITLE
[Manual Backport 3.6][CVE] Bump qs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "tough-cookie": "^4.1.3",
     "semver": "^7.5.2",
     "@cypress/request": "^3.0.9",
-    "**/eslint/cross-spawn": "^7.0.5"
+    "**/eslint/cross-spawn": "^7.0.5",
+    "qs": "^6.14.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1361,10 +1361,10 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-qs@6.14.0:
-  version "6.14.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.0.tgz#c63fa40680d2c5c941412a0e899c89af60c0a930"
-  integrity sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==
+qs@6.14.0, qs@^6.14.1:
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.0.tgz#db8fd5d1b1d2d6b5b33adaf87429805f1909e7b3"
+  integrity sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==
   dependencies:
     side-channel "^1.1.0"
 


### PR DESCRIPTION
### Description
Manual Backport of https://github.com/opensearch-project/dashboards-query-workbench/pull/536

### Issues Resolved
* Relate https://github.com/opensearch-project/dashboards-query-workbench/pull/536
* Resolve https://advisories.opensearch.org/advisories/CVE-2025-15284
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).