### PR TITLE
[CVE-2026-32141][CVE-2026-33228] Bump flatted version

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@cypress/request": "^3.0.9",
     "**/eslint/cross-spawn": "^7.0.5",
     "qs": "^6.14.1",
+    "flatted": "^3.4.2",
     "lodash": "^4.18.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -727,10 +727,10 @@ flat-cache@^2.0.1:
     rimraf "2.6.3"
     write "1.0.3"
 
-flatted@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz"
-  integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+flatted@^2.0.0, flatted@^3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.2.tgz#f5c23c107f0f37de8dbdf24f13722b3b98d52726"
+  integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
 
 forever-agent@~0.6.1:
   version "0.6.1"


### PR DESCRIPTION
### Description

Bump flatted version to address CVE-2026-32141 (unbounded recursion DoS in `parse()`) and CVE-2026-33228 (prototype pollution via `parse()`)

### Issues Resolved

- CVE-2026-32141
- CVE-2026-33228
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).