### PR TITLE
[Backport 2.19] Bump yaml from 2.3.2 to 2.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ansi-regex": "^5.0.1",
     "eslint-utils": "^2.0.0",
     "json-schema": "^0.4.0",
-    "yaml": "^2.2.2",
+    "yaml": "^2.8.3",
     "tough-cookie": "^4.1.3",
     "semver": "^7.5.2",
     "@cypress/request": "^3.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2371,10 +2371,10 @@ yallist@^4.0.0:
   resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@^2.2.2, yaml@~2.5.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.2.tgz#f522db4313c671a0ca963a75670f1c12ea909144"
-  integrity sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==
+yaml@^2.8.3, yaml@~2.5.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.9.0.tgz#78274afd93598a1dfdd6130df6a566defcbf9aa4"
+  integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==
 
 yargs-parser@^21.0.1:
   version "21.1.1"


### PR DESCRIPTION
### Description
Bump `yaml` resolution from `^2.2.2` to `^2.8.3` (resolves to 2.9.0) to address GHSA-48c2-rrv3-qjmp (versions
  >=2.0.0 <2.8.3 are vulnerable).
 
### Issues Resolved
Resolves CVE-2026-33532.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).