### PR TITLE
Migrate Jest test suite to Jest 30 + jsdom 26

### DIFF
--- a/public/components/Header/Header.test.tsx
+++ b/public/components/Header/Header.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import { Header } from './Header';
 

--- a/public/components/Header/__snapshots__/Header.test.tsx.snap
+++ b/public/components/Header/__snapshots__/Header.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Header /> spec renders the component 1`] = `
 <div>

--- a/public/components/Main/__snapshots__/main.test.tsx.snap
+++ b/public/components/Main/__snapshots__/main.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Main /> spec click clear button 1`] = `
 <div>

--- a/public/components/Main/main.test.tsx
+++ b/public/components/Main/main.test.tsx
@@ -96,7 +96,7 @@ describe('<Main /> spec', () => {
     client.get = jest.fn().mockResolvedValue(mockDatasourcesQuery);
 
     client.post = jest.fn(() => {
-      return (Promise.resolve(mockOpenSearchIndicies) as unknown) as HttpResponse;
+      return Promise.resolve(mockOpenSearchIndicies) as unknown as HttpResponse;
     });
     const { getByText } = await render(
       <Main httpClient={client} setBreadcrumbs={setBreadcrumbsMock} />
@@ -172,10 +172,10 @@ describe('<Main /> spec', () => {
     const client = httpClientMock;
     client.post = jest.fn(() => {
       if (postRequestFlag > 0)
-        return Promise.resolve((mockNotOkQueryResultResponse as unknown) as HttpResponse);
+        return Promise.resolve(mockNotOkQueryResultResponse as unknown as HttpResponse);
       else {
         postRequestFlag = 1;
-        return Promise.resolve((mockOpenSearchTreeQuery as unknown) as HttpResponse);
+        return Promise.resolve(mockOpenSearchTreeQuery as unknown as HttpResponse);
       }
     });
     client.get = jest.fn().mockResolvedValue(mockDatasourcesQuery);
@@ -201,10 +201,10 @@ describe('<Main /> spec', () => {
     const client = httpClientMock;
     client.post = jest.fn(() => {
       if (postRequestFlag > 0)
-        return Promise.resolve((mockQueryTranslationResponse as unknown) as HttpResponse);
+        return Promise.resolve(mockQueryTranslationResponse as unknown as HttpResponse);
       else {
         postRequestFlag = 1;
-        return Promise.resolve((mockOpenSearchTreeQuery as unknown) as HttpResponse);
+        return Promise.resolve(mockOpenSearchTreeQuery as unknown as HttpResponse);
       }
     });
 
@@ -228,7 +228,7 @@ describe('<Main /> spec', () => {
     const client = httpClientMock;
     client.get = jest.fn().mockResolvedValue(mockDatasourcesQuery);
     client.post = jest.fn(() => {
-      return Promise.resolve((mockOpenSearchTreeQuery as unknown) as HttpResponse);
+      return Promise.resolve(mockOpenSearchTreeQuery as unknown as HttpResponse);
     });
 
     const { getByText } = await render(

--- a/public/components/Main/main.test.tsx
+++ b/public/components/Main/main.test.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { HttpResponse } from '../../../../../src/core/public';

--- a/public/components/PPLPage/PPLPage.test.tsx
+++ b/public/components/PPLPage/PPLPage.test.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { PPLPage } from './PPLPage';

--- a/public/components/PPLPage/__snapshots__/PPLPage.test.tsx.snap
+++ b/public/components/PPLPage/__snapshots__/PPLPage.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<PPLPage /> spec renders the component 1`] = `
 <div>

--- a/public/components/QueryLanguageSwitch/Switch.test.tsx
+++ b/public/components/QueryLanguageSwitch/Switch.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import { Switch } from './Switch';
 

--- a/public/components/QueryLanguageSwitch/__snapshots__/Switch.test.tsx.snap
+++ b/public/components/QueryLanguageSwitch/__snapshots__/Switch.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Switch /> spec renders the component 1`] = `
 <div>

--- a/public/components/QueryResults/QueryResults.test.tsx
+++ b/public/components/QueryResults/QueryResults.test.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import { configure, fireEvent, render } from '@testing-library/react';
 import { AsyncQueryStatus } from '../../../common/types/index';
 

--- a/public/components/QueryResults/QueryResults.test.tsx
+++ b/public/components/QueryResults/QueryResults.test.tsx
@@ -66,10 +66,7 @@ function renderSQLQueryResults(
 
 describe('<QueryResults /> spec', () => {
   it('renders the component with no data', async () => {
-    ((window as unknown) as Record<
-      string,
-      unknown
-    >).HTMLElement.prototype.scrollBy = function () {};
+    (window as unknown as Record<string, unknown>).HTMLElement.prototype.scrollBy = function () {};
     expect(document.body.children[0]).toMatchSnapshot();
   });
 });
@@ -84,7 +81,7 @@ describe('<QueryResults with data/> spec', () => {
   const getCsv = jest.fn();
   const getText = jest.fn();
   const setIsResultFullScreen = jest.fn();
-  ((window as unknown) as Record<string, unknown>).HTMLElement.prototype.scrollBy = jest.fn();
+  (window as unknown as Record<string, unknown>).HTMLElement.prototype.scrollBy = jest.fn();
 
   it('renders the component with mock query results', async () => {
     const { getAllByRole, getByText, getAllByText, getAllByLabelText } = renderSQLQueryResults(
@@ -200,10 +197,7 @@ function renderPPLQueryResults(
 
 describe('<QueryResults /> empty spec', () => {
   it('renders the component with no data', async () => {
-    ((window as unknown) as Record<
-      string,
-      unknown
-    >).HTMLElement.prototype.scrollBy = function () {};
+    (window as unknown as Record<string, unknown>).HTMLElement.prototype.scrollBy = function () {};
 
     expect(document.body.children[0]).toMatchSnapshot();
   });
@@ -219,7 +213,7 @@ describe('<QueryResults with PPL data/> spec', () => {
   const getCsv = jest.fn();
   const getText = jest.fn();
   const setIsResultFullScreen = jest.fn();
-  ((window as unknown) as Record<string, unknown>).HTMLElement.prototype.scrollBy = jest.fn();
+  (window as unknown as Record<string, unknown>).HTMLElement.prototype.scrollBy = jest.fn();
 
   it('renders the component with mock query results', async () => {
     const { getAllByRole, getByText, getAllByText, getAllByLabelText } = renderPPLQueryResults(

--- a/public/components/QueryResults/QueryResultsBody.test.tsx
+++ b/public/components/QueryResults/QueryResultsBody.test.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { QueryResultsBody } from './QueryResultsBody';

--- a/public/components/QueryResults/QueryResultsBody.test.tsx
+++ b/public/components/QueryResults/QueryResultsBody.test.tsx
@@ -118,29 +118,23 @@ describe('<QueryResultsBody with SQL language/> spec', () => {
       mockSortableColumns[0].name
     );
 
-    ((window as unknown) as Record<
-      string,
-      unknown
-    >).HTMLElement.prototype.scrollIntoView = function () {};
+    (window as unknown as Record<string, unknown>).HTMLElement.prototype.scrollIntoView =
+      function () {};
 
-    const {
-      getAllByText,
-      getAllByLabelText,
-      getByText,
-      getByPlaceholderText,
-    } = renderSQLQueryResultsBody(
-      undefined,
-      mockQueryResults[0].data,
-      mockQueryResultJDBCResponse.data.resp,
-      mockSortableProperties,
-      mockSuccessfulMessage,
-      onQueryChange,
-      updateExpandedMap,
-      onChangeItemsPerPage,
-      getJdbc,
-      getCsv,
-      getText
-    );
+    const { getAllByText, getAllByLabelText, getByText, getByPlaceholderText } =
+      renderSQLQueryResultsBody(
+        undefined,
+        mockQueryResults[0].data,
+        mockQueryResultJDBCResponse.data.resp,
+        mockSortableProperties,
+        mockSuccessfulMessage,
+        onQueryChange,
+        updateExpandedMap,
+        onChangeItemsPerPage,
+        getJdbc,
+        getCsv,
+        getText
+      );
     expect(document.body.children[0]).toMatchSnapshot();
 
     // Test sorting
@@ -290,10 +284,8 @@ describe('<QueryResultsBody with PPL language/> spec', () => {
       mockSortableColumns[0].name
     );
 
-    ((window as unknown) as Record<
-      string,
-      unknown
-    >).HTMLElement.prototype.scrollIntoView = function () {};
+    (window as unknown as Record<string, unknown>).HTMLElement.prototype.scrollIntoView =
+      function () {};
 
     const { getAllByText, getAllByLabelText, getByText } = renderPPLQueryResultsBody(
       undefined,

--- a/public/components/QueryResults/__snapshots__/QueryResults.test.tsx.snap
+++ b/public/components/QueryResults/__snapshots__/QueryResults.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<AsyncQueryResults /> spec renders async query failure component 1`] = `
 <div>

--- a/public/components/QueryResults/__snapshots__/QueryResultsBody.test.tsx.snap
+++ b/public/components/QueryResults/__snapshots__/QueryResultsBody.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<QueryResultsBody with PPL language/> spec renders component with mock QueryResults data 1`] = `
 <div>

--- a/public/components/SQLPage/SQLPage.test.tsx
+++ b/public/components/SQLPage/SQLPage.test.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { SQLPage } from './SQLPage';

--- a/public/components/SQLPage/__snapshots__/SQLPage.test.tsx.snap
+++ b/public/components/SQLPage/__snapshots__/SQLPage.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SQLPage /> spec renders the component 1`] = `
 <div>

--- a/public/components/SQLPage/__tests__/DataSelect.test.tsx
+++ b/public/components/SQLPage/__tests__/DataSelect.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import '@testing-library/jest-dom';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { HttpResponse } from '../../../../../../src/core/public';

--- a/public/components/SQLPage/__tests__/DataSelect.test.tsx
+++ b/public/components/SQLPage/__tests__/DataSelect.test.tsx
@@ -16,7 +16,7 @@ describe('Renders the Datasource picker component', () => {
   it('fetches the datasources and selects S3glue as source', async () => {
     const client = httpClientMock;
     client.get = jest.fn(() => {
-      return (Promise.resolve(mockDataSelectQuery) as unknown) as HttpResponse;
+      return Promise.resolve(mockDataSelectQuery) as unknown as HttpResponse;
     });
 
     const mockOnSelect = jest.fn();
@@ -36,7 +36,7 @@ describe('Renders the Datasource picker component', () => {
   it('fetches the datasources and selects Opensearch as source', async () => {
     const client = httpClientMock;
     client.get = jest.fn(() => {
-      return (Promise.resolve(mockDataSelectQuery) as unknown) as HttpResponse;
+      return Promise.resolve(mockDataSelectQuery) as unknown as HttpResponse;
     });
 
     const mockOnSelect = jest.fn();

--- a/public/components/SQLPage/__tests__/__snapshots__/CreateButton.test.tsx.snap
+++ b/public/components/SQLPage/__tests__/__snapshots__/CreateButton.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CreateButton opens and closes the popover 1`] = `
 <div>

--- a/public/components/SQLPage/__tests__/__snapshots__/DataSelect.test.tsx.snap
+++ b/public/components/SQLPage/__tests__/__snapshots__/DataSelect.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Renders the Datasource picker component fetches the datasources and selects Opensearch as source 1`] = `
 <body>

--- a/public/components/SQLPage/__tests__/__snapshots__/acceleration_index_flyout.test.tsx.snap
+++ b/public/components/SQLPage/__tests__/__snapshots__/acceleration_index_flyout.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Acceleration index flyout renders acceleration flyout with covering index 1`] = `
 <body

--- a/public/components/SQLPage/__tests__/__snapshots__/table_view.test.tsx.snap
+++ b/public/components/SQLPage/__tests__/__snapshots__/table_view.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Render databases in tree fetches Materialized view in the Side tree 1`] = `
 <div>

--- a/public/components/SQLPage/__tests__/table_view.test.tsx
+++ b/public/components/SQLPage/__tests__/table_view.test.tsx
@@ -34,10 +34,10 @@ describe('Render databases in tree', () => {
   it('fetches the tree when datasource is S3', async () => {
     const client = httpClientMock;
     client.post = jest.fn(() => {
-      return (Promise.resolve(mockJobId) as unknown) as HttpResponse;
+      return Promise.resolve(mockJobId) as unknown as HttpResponse;
     });
     client.get = jest.fn(() => {
-      return (Promise.resolve(mockDatabaseQuery) as unknown) as HttpResponse;
+      return Promise.resolve(mockDatabaseQuery) as unknown as HttpResponse;
     });
     const asyncTest = () => {
       render(
@@ -59,7 +59,7 @@ describe('Render databases in tree', () => {
   it('fetches and displays indicies when datasource is OpenSearch', async () => {
     const client = httpClientMock;
     client.post = jest.fn(() => {
-      return (Promise.resolve(mockOpenSearchIndicies) as unknown) as HttpResponse;
+      return Promise.resolve(mockOpenSearchIndicies) as unknown as HttpResponse;
     });
 
     render(
@@ -79,10 +79,10 @@ describe('Render databases in tree', () => {
   it('fetches default database in the side tree', async () => {
     const client = httpClientMock;
     client.post = jest.fn(() => {
-      return (Promise.resolve(mockJobId) as unknown) as HttpResponse;
+      return Promise.resolve(mockJobId) as unknown as HttpResponse;
     });
     client.get = jest.fn(() => {
-      return (Promise.resolve(mockDatabaseQuery) as unknown) as HttpResponse;
+      return Promise.resolve(mockDatabaseQuery) as unknown as HttpResponse;
     });
 
     const { getByText } = render(
@@ -103,10 +103,10 @@ describe('Render databases in tree', () => {
   it('fetches Materialized view in the Side tree', async () => {
     const client = httpClientMock;
     client.post = jest.fn(() => {
-      return (Promise.resolve(mockJobId) as unknown) as HttpResponse;
+      return Promise.resolve(mockJobId) as unknown as HttpResponse;
     });
     client.get = jest.fn(() => {
-      return (Promise.resolve(mockDatabaseQuery) as unknown) as HttpResponse;
+      return Promise.resolve(mockDatabaseQuery) as unknown as HttpResponse;
     });
 
     const { getByText } = render(
@@ -127,10 +127,10 @@ describe('Render databases in tree', () => {
 
     await waitFor(() => {
       client.post = jest.fn(() => {
-        return (Promise.resolve(mockJobId) as unknown) as HttpResponse;
+        return Promise.resolve(mockJobId) as unknown as HttpResponse;
       });
       client.get = jest.fn(() => {
-        return (Promise.resolve(mockMVquery) as unknown) as HttpResponse;
+        return Promise.resolve(mockMVquery) as unknown as HttpResponse;
       });
 
       expect(getByText('http_count_view')).toBeInTheDocument();
@@ -141,10 +141,10 @@ describe('Render databases in tree', () => {
   it('fetches No materilaized views badge in side tree', async () => {
     const client = httpClientMock;
     client.post = jest.fn(() => {
-      return (Promise.resolve(mockJobId) as unknown) as HttpResponse;
+      return Promise.resolve(mockJobId) as unknown as HttpResponse;
     });
     client.get = jest.fn(() => {
-      return (Promise.resolve(mockDatabaseQuery) as unknown) as HttpResponse;
+      return Promise.resolve(mockDatabaseQuery) as unknown as HttpResponse;
     });
 
     const { getByText } = render(
@@ -165,10 +165,10 @@ describe('Render databases in tree', () => {
 
     await waitFor(() => {
       client.post = jest.fn(() => {
-        return (Promise.resolve(mockJobId) as unknown) as HttpResponse;
+        return Promise.resolve(mockJobId) as unknown as HttpResponse;
       });
       client.get = jest.fn(() => {
-        return (Promise.resolve(mockMVEmptyQuery) as unknown) as HttpResponse;
+        return Promise.resolve(mockMVEmptyQuery) as unknown as HttpResponse;
       });
 
       expect(getByText('No Materialized View')).toBeInTheDocument();
@@ -179,10 +179,10 @@ describe('Render databases in tree', () => {
   it('fetches and displays tables in the side tree', async () => {
     const client = httpClientMock;
     client.post = jest.fn(() => {
-      return (Promise.resolve(mockJobId) as unknown) as HttpResponse;
+      return Promise.resolve(mockJobId) as unknown as HttpResponse;
     });
     client.get = jest.fn(() => {
-      return (Promise.resolve(mockDatabaseQuery) as unknown) as HttpResponse;
+      return Promise.resolve(mockDatabaseQuery) as unknown as HttpResponse;
     });
     const { getByText } = render(
       <TableView
@@ -197,10 +197,10 @@ describe('Render databases in tree', () => {
 
     await act(() => {
       client.post = jest.fn(() => {
-        return (Promise.resolve(mockJobId) as unknown) as HttpResponse;
+        return Promise.resolve(mockJobId) as unknown as HttpResponse;
       });
       client.get = jest.fn(() => {
-        return (Promise.resolve(mockTableQuery) as unknown) as HttpResponse;
+        return Promise.resolve(mockTableQuery) as unknown as HttpResponse;
       });
     });
     await waitFor(() => {
@@ -212,10 +212,10 @@ describe('Render databases in tree', () => {
   it('fetches and displays skipping index in the side tree', async () => {
     const client = httpClientMock;
     client.post = jest.fn(() => {
-      return (Promise.resolve(mockJobId) as unknown) as HttpResponse;
+      return Promise.resolve(mockJobId) as unknown as HttpResponse;
     });
     client.get = jest.fn(() => {
-      return (Promise.resolve(mockDatabaseQuery) as unknown) as HttpResponse;
+      return Promise.resolve(mockDatabaseQuery) as unknown as HttpResponse;
     });
     const { getByText } = render(
       <TableView
@@ -230,10 +230,10 @@ describe('Render databases in tree', () => {
 
     await act(() => {
       client.post = jest.fn(() => {
-        return (Promise.resolve(mockJobId) as unknown) as HttpResponse;
+        return Promise.resolve(mockJobId) as unknown as HttpResponse;
       });
       client.get = jest.fn(() => {
-        return (Promise.resolve(mockTableQuery) as unknown) as HttpResponse;
+        return Promise.resolve(mockTableQuery) as unknown as HttpResponse;
       });
     });
     await waitFor(() => {
@@ -242,16 +242,16 @@ describe('Render databases in tree', () => {
     fireEvent.click(getByText('http_logs2'));
     act(() => {
       client.post = jest.fn(() => {
-        return (Promise.resolve(mockJobId) as unknown) as HttpResponse;
+        return Promise.resolve(mockJobId) as unknown as HttpResponse;
       });
       client.get = jest.fn(() => {
-        return (Promise.resolve(mockSkippingIndexQuery) as unknown) as HttpResponse;
+        return Promise.resolve(mockSkippingIndexQuery) as unknown as HttpResponse;
       });
       client.post = jest.fn(() => {
-        return (Promise.resolve(mockJobId) as unknown) as HttpResponse;
+        return Promise.resolve(mockJobId) as unknown as HttpResponse;
       });
       client.get = jest.fn(() => {
-        return (Promise.resolve(mockCoveringIndexQuery) as unknown) as HttpResponse;
+        return Promise.resolve(mockCoveringIndexQuery) as unknown as HttpResponse;
       });
     });
     await waitFor(() => {
@@ -264,10 +264,10 @@ describe('Render databases in tree', () => {
   it('fetches and displays No indicies in the side tree', async () => {
     const client = httpClientMock;
     client.post = jest.fn(() => {
-      return (Promise.resolve(mockJobId) as unknown) as HttpResponse;
+      return Promise.resolve(mockJobId) as unknown as HttpResponse;
     });
     client.get = jest.fn(() => {
-      return (Promise.resolve(mockDatabaseQuery) as unknown) as HttpResponse;
+      return Promise.resolve(mockDatabaseQuery) as unknown as HttpResponse;
     });
     const { getByText } = render(
       <TableView
@@ -282,10 +282,10 @@ describe('Render databases in tree', () => {
 
     await act(() => {
       client.post = jest.fn(() => {
-        return (Promise.resolve(mockJobId) as unknown) as HttpResponse;
+        return Promise.resolve(mockJobId) as unknown as HttpResponse;
       });
       client.get = jest.fn(() => {
-        return (Promise.resolve(mockTableQuery) as unknown) as HttpResponse;
+        return Promise.resolve(mockTableQuery) as unknown as HttpResponse;
       });
     });
     await waitFor(() => {
@@ -294,16 +294,16 @@ describe('Render databases in tree', () => {
     fireEvent.click(getByText('http_logs2'));
     act(() => {
       client.post = jest.fn(() => {
-        return (Promise.resolve(mockJobId) as unknown) as HttpResponse;
+        return Promise.resolve(mockJobId) as unknown as HttpResponse;
       });
       client.get = jest.fn(() => {
-        return (Promise.resolve(mockEmptySkippingIndexQuery) as unknown) as HttpResponse;
+        return Promise.resolve(mockEmptySkippingIndexQuery) as unknown as HttpResponse;
       });
       client.post = jest.fn(() => {
-        return (Promise.resolve(mockJobId) as unknown) as HttpResponse;
+        return Promise.resolve(mockJobId) as unknown as HttpResponse;
       });
       client.get = jest.fn(() => {
-        return (Promise.resolve(mockEmptyCoveringIndexQuery) as unknown) as HttpResponse;
+        return Promise.resolve(mockEmptyCoveringIndexQuery) as unknown as HttpResponse;
       });
     });
     await waitFor(() => {

--- a/public/components/SQLPage/__tests__/table_view.test.tsx
+++ b/public/components/SQLPage/__tests__/table_view.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import '@testing-library/jest-dom';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import {
   act,
   fireEvent,

--- a/public/components/SQLPage/sql_catalog_tree/__tests__/__snapshots__/catalog_s3_loaded.test.tsx.snap
+++ b/public/components/SQLPage/sql_catalog_tree/__tests__/__snapshots__/catalog_s3_loaded.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Test Catalog tree Loading state S3 catalog tree 1`] = `
 <div>

--- a/public/components/SQLPage/sql_catalog_tree/__tests__/__snapshots__/catalog_s3_loading.test.tsx.snap
+++ b/public/components/SQLPage/sql_catalog_tree/__tests__/__snapshots__/catalog_s3_loading.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Test Catalog tree Loading state S3 catalog tree 1`] = `
 <div>

--- a/public/components/SQLPage/sql_catalog_tree/__tests__/__snapshots__/catalog_tree.test.tsx.snap
+++ b/public/components/SQLPage/sql_catalog_tree/__tests__/__snapshots__/catalog_tree.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Test Catalog tree Loading state OpenSearch catalog tree 1`] = `
 <div>

--- a/public/components/acceleration/create/__tests__/__snapshots__/create_acceleration.test.tsx.snap
+++ b/public/components/acceleration/create/__tests__/__snapshots__/create_acceleration.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Create acceleration flyout components renders acceleration flyout component with default options 1`] = `
 <body
@@ -203,7 +203,7 @@ exports[`Create acceleration flyout components renders acceleration flyout compo
                                 value=""
                               />
                               <div
-                                style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                               />
                             </div>
                           </div>
@@ -297,7 +297,7 @@ exports[`Create acceleration flyout components renders acceleration flyout compo
                                 value=""
                               />
                               <div
-                                style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                               />
                             </div>
                           </div>
@@ -391,7 +391,7 @@ exports[`Create acceleration flyout components renders acceleration flyout compo
                                 value=""
                               />
                               <div
-                                style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                               />
                             </div>
                           </div>
@@ -532,7 +532,7 @@ exports[`Create acceleration flyout components renders acceleration flyout compo
                                 value=""
                               />
                               <div
-                                style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                               />
                             </div>
                           </div>

--- a/public/components/acceleration/create/__tests__/__snapshots__/create_acceleration_header.test.tsx.snap
+++ b/public/components/acceleration/create/__tests__/__snapshots__/create_acceleration_header.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Acceleration header renders acceleration flyout header 1`] = `
 <body>

--- a/public/components/acceleration/selectors/__tests__/__snapshots__/define_index_options.test.tsx.snap
+++ b/public/components/acceleration/selectors/__tests__/__snapshots__/define_index_options.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Index options acceleration components renders acceleration index options with covering index options 1`] = `
 <body>

--- a/public/components/acceleration/selectors/__tests__/__snapshots__/index_setting_options.test.tsx.snap
+++ b/public/components/acceleration/selectors/__tests__/__snapshots__/index_setting_options.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Index settings acceleration components renders acceleration index settings with default options 1`] = `
 <body>
@@ -101,7 +101,7 @@ exports[`Index settings acceleration components renders acceleration index setti
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>
@@ -469,7 +469,7 @@ exports[`Index settings acceleration components renders acceleration index setti
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>
@@ -838,7 +838,7 @@ exports[`Index settings acceleration components renders acceleration index setti
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>

--- a/public/components/acceleration/selectors/__tests__/__snapshots__/index_type_selector.test.tsx.snap
+++ b/public/components/acceleration/selectors/__tests__/__snapshots__/index_type_selector.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Index type selector components renders type selector with default options 1`] = `
 <body>
@@ -90,7 +90,7 @@ exports[`Index type selector components renders type selector with default optio
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>
@@ -223,7 +223,7 @@ exports[`Index type selector components renders type selector with different opt
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>

--- a/public/components/acceleration/selectors/__tests__/__snapshots__/source_selector.test.tsx.snap
+++ b/public/components/acceleration/selectors/__tests__/__snapshots__/source_selector.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Source selector components renders source selector with default options 1`] = `
 <body>
@@ -80,7 +80,7 @@ exports[`Source selector components renders source selector with default options
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>
@@ -174,7 +174,7 @@ exports[`Source selector components renders source selector with default options
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>
@@ -268,7 +268,7 @@ exports[`Source selector components renders source selector with default options
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>
@@ -392,7 +392,7 @@ exports[`Source selector components renders source selector with different optio
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>
@@ -487,7 +487,7 @@ exports[`Source selector components renders source selector with different optio
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>
@@ -585,7 +585,7 @@ exports[`Source selector components renders source selector with different optio
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>

--- a/public/components/acceleration/visual_editors/__tests__/__snapshots__/query_visual_editor.test.tsx.snap
+++ b/public/components/acceleration/visual_editors/__tests__/__snapshots__/query_visual_editor.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Visual builder components renders visual builder with covering index options 1`] = `
 <body>

--- a/public/components/acceleration/visual_editors/covering_index/__tests__/__snapshots__/covering_index_builder.test.tsx.snap
+++ b/public/components/acceleration/visual_editors/covering_index/__tests__/__snapshots__/covering_index_builder.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Covering index builder components renders covering index builder  with different options 1`] = `
 <body>

--- a/public/components/acceleration/visual_editors/materialized_view/__tests__/__snapshots__/add_column_popover.test.tsx.snap
+++ b/public/components/acceleration/visual_editors/materialized_view/__tests__/__snapshots__/add_column_popover.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Column popover components in materialized view renders column popover components in materialized view with default options 1`] = `
 <body>

--- a/public/components/acceleration/visual_editors/materialized_view/__tests__/__snapshots__/column_expression.test.tsx.snap
+++ b/public/components/acceleration/visual_editors/materialized_view/__tests__/__snapshots__/column_expression.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Column expression components in materialized view renders column expression components in materialized view with default options 1`] = `
 <body>

--- a/public/components/acceleration/visual_editors/materialized_view/__tests__/__snapshots__/group_by_tumble_expression.test.tsx.snap
+++ b/public/components/acceleration/visual_editors/materialized_view/__tests__/__snapshots__/group_by_tumble_expression.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Group by components in materialized view renders group by components in materialized view with default options 1`] = `
 <body>

--- a/public/components/acceleration/visual_editors/materialized_view/__tests__/__snapshots__/materialized_view_builder.test.tsx.snap
+++ b/public/components/acceleration/visual_editors/materialized_view/__tests__/__snapshots__/materialized_view_builder.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Builder components in materialized view renders builder components in materialized view with default options 1`] = `
 <body>

--- a/public/components/acceleration/visual_editors/skipping_index/__tests__/__snapshots__/add_fields_modal.test.tsx.snap
+++ b/public/components/acceleration/visual_editors/skipping_index/__tests__/__snapshots__/add_fields_modal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Add fields modal in skipping index renders add fields modal in skipping index with default options 1`] = `
 <body

--- a/public/components/acceleration/visual_editors/skipping_index/__tests__/__snapshots__/delete_fields_modal.test.tsx.snap
+++ b/public/components/acceleration/visual_editors/skipping_index/__tests__/__snapshots__/delete_fields_modal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Delete fields modal in skipping index renders delete fields modal in skipping index with default options 1`] = `
 <body

--- a/public/components/acceleration/visual_editors/skipping_index/__tests__/__snapshots__/skipping_index_builder.test.tsx.snap
+++ b/public/components/acceleration/visual_editors/skipping_index/__tests__/__snapshots__/skipping_index_builder.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Builder components in materialized view renders builder components in materialized view with default options 1`] = `
 <body>

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -6,16 +6,24 @@
 module.exports = {
   rootDir: '../',
   setupFiles: ['<rootDir>/test/polyfills.ts', '<rootDir>/test/setupTests.ts'],
-  setupFilesAfterEnv: ['<rootDir>/test/setup.jest.ts'],
+  setupFilesAfterEnv: ['jest-location-mock', '<rootDir>/test/setup.jest.ts'],
   roots: ['<rootDir>'],
   coverageDirectory: './coverage',
   moduleNameMapper: {
     '\\.(css|less|scss)$': '<rootDir>/test/mocks/styleMock.ts',
     '^ui/(.*)': '<rootDir>/../../src/ui/public/$1/',
+    // query-string v9 is pure ESM; this shim restores the default-import shape
+    // (`import qs from 'query-string'`) under Jest's CJS transform.
+    '^query-string$': '<rootDir>/test/mocks/queryStringMock.js',
   },
   transform: {
     '^.+\\.(js|jsx|ts|tsx)$': '<rootDir>/test/babelTransform.js',
   },
+  // query-string v9 (and its ESM-only deps) must be transformed by Babel rather than
+  // ignored, so the query-string moduleNameMapper shim can load the real package.
+  transformIgnorePatterns: [
+    '[/\\\\]node_modules(?![/\\\\](query-string|decode-uri-component|filter-obj|split-on-first))[/\\\\].+\\.js$',
+  ],
   coverageReporters: ['lcov', 'text', 'cobertura'],
   testMatch: ['**/*.test.ts', '**/*.test.tsx'],
   collectCoverageFrom: [
@@ -40,5 +48,14 @@ module.exports = {
   clearMocks: true,
   testPathIgnorePatterns: ['<rootDir>/build/', '<rootDir>/node_modules/'],
   testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    url: 'http://localhost:5601',
+  },
+  // Retain Jest 28 snapshot defaults; Jest 29 flipped escapeString and printBasicPrototype to false,
+  // which would invalidate existing snapshots. See https://jestjs.io/docs/29.0/upgrading-to-jest29
+  snapshotFormat: {
+    escapeString: true,
+    printBasicPrototype: true,
+  },
   testTimeout: 20000,
 };

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -52,7 +52,7 @@ module.exports = {
     url: 'http://localhost:5601',
   },
   // Retain Jest 28 snapshot defaults; Jest 29 flipped escapeString and printBasicPrototype to false,
-  // which would invalidate existing snapshots. See https://jestjs.io/docs/29.0/upgrading-to-jest29
+  // which would invalidate existing snapshots. See https://jestjs.io/docs/upgrading-to-jest29
   snapshotFormat: {
     escapeString: true,
     printBasicPrototype: true,

--- a/test/mocks/queryStringMock.js
+++ b/test/mocks/queryStringMock.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * query-string v9 is a pure ESM module whose index.js has only a default export.
+ * Under Jest's CJS transform the default-import shape (`import qs from 'query-string'`)
+ * breaks. This shim (set as the moduleNameMapper target for 'query-string') loads the
+ * real package from the parent repo's node_modules via an absolute file path so Jest's
+ * moduleNameMapper does not intercept the require and recurse into this file.
+ *
+ * Mirrors src/dev/jest/mocks/query_string_mock.js in the parent repo.
+ */
+
+// eslint-disable-next-line import/no-dynamic-require
+const mod = require(require('path').resolve(
+  __dirname,
+  '../../../../node_modules/query-string/index.js'
+));
+
+const api = mod && mod.__esModule && typeof mod.stringify !== 'function' ? mod.default : mod;
+
+module.exports = {
+  __esModule: true,
+  default: api,
+};

--- a/test/mocks/queryStringMock.js
+++ b/test/mocks/queryStringMock.js
@@ -14,10 +14,9 @@
  */
 
 // eslint-disable-next-line import/no-dynamic-require
-const mod = require(require('path').resolve(
-  __dirname,
-  '../../../../node_modules/query-string/index.js'
-));
+const mod = require(
+  require('path').resolve(__dirname, '../../../../node_modules/query-string/index.js')
+);
 
 const api = mod && mod.__esModule && typeof mod.stringify !== 'function' ? mod.default : mod;
 

--- a/test/setup.jest.ts
+++ b/test/setup.jest.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import { configure } from '@testing-library/react';
 import { coreRefs } from '../public/framework/core_refs';
 import { coreStartMock } from '../test/mocks/coreMocks';
@@ -43,3 +43,37 @@ jest.mock('@elastic/eui/lib/components/icon', () => ({
 coreRefs.http = coreStartMock.http;
 coreRefs.savedObjectsClient = coreStartMock.savedObjects.client;
 coreRefs.toasts = coreStartMock.notifications.toasts;
+
+// jest-location-mock uses process.env.HOST as the base URL for its window.location mock.
+// Set it to match testEnvironmentOptions.url so window.location.origin is 'http://localhost:5601'.
+process.env.HOST = 'http://localhost:5601';
+
+// Mock window.matchMedia (used by Monaco editor). Make it configurable so tests can override it.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  configurable: true,
+  value: jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // Deprecated
+    removeListener: jest.fn(), // Deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
+
+// jsdom 26 marks window.localStorage and window.sessionStorage as non-configurable.
+// Re-declare them as configurable once here so individual tests can override them
+// with Object.defineProperty without hitting "Cannot redefine property" errors.
+['localStorage', 'sessionStorage'].forEach((key) => {
+  const descriptor = Object.getOwnPropertyDescriptor(window, key);
+  if (descriptor && !descriptor.configurable) {
+    Object.defineProperty(window, key, {
+      configurable: true,
+      writable: true,
+      value: descriptor.value,
+    });
+  }
+});


### PR DESCRIPTION
Closes #576

### Description

Migrate this plugin's Jest test suite to run under **Jest 30.4.2 + jsdom 26.1.0**, following the
core OpenSearch-Dashboards upgrade in opensearch-project/OpenSearch-Dashboards#12381. The plugin
runs its tests against the parent repo's jest binary, so it breaks once the core upgrade lands.

**Result:** full suite green — `31 suites / 127 tests / 81 snapshots passed`, exit 0.

#### Common changes (shared across the plugin-migration campaign)
- **Config (`test/jest.config.js`):** added `jest-location-mock` as the first `setupFilesAfterEnv`
  entry; added `testEnvironmentOptions: { url: 'http://localhost:5601' }`; added the
  `snapshotFormat: { escapeString: true, printBasicPrototype: true }` compatibility shim (Jest 29
  flipped these defaults, which would otherwise invalidate existing snapshots).
- **Setup (`test/setup.jest.ts`):** switched the deprecated
  `@testing-library/jest-dom/extend-expect` import to `@testing-library/jest-dom`; made the
  `matchMedia` mock `configurable` (used by the Monaco editor); set
  `process.env.HOST = 'http://localhost:5601'` so jest-location-mock's `window.location.origin`
  matches `testEnvironmentOptions.url`; re-declared non-configurable `localStorage`/`sessionStorage`
  as configurable (jsdom 26) so individual tests can still override them.
- **jest-dom import fix:** replaced `@testing-library/jest-dom/extend-expect` with
  `@testing-library/jest-dom` across the test files that imported it directly (Header, Main,
  PPLPage, Switch, QueryResults, QueryResultsBody, SQLPage, DataSelect, table_view).
- **Snapshots:** bumped the snapshot header URL (`goo.gl/fbAQLP` →
  `jestjs.io/docs/snapshot-testing`) across 29 `.snap` files — Jest 30 refuses to load the old
  header. Regenerated 4 snapshots; verified every non-header diff is jsdom-26 CSS serialization
  only (dropped `font-family: -webkit-small-control` on hidden EUI combobox measure spans), no
  content regressions.

#### Plugin-specific changes
- **`query-string` v9 ESM fix:** `query-string` v9 is a pure-ESM module with only a default export,
  which breaks the `import qs from 'query-string'` shape under Jest's CJS transform. Added a
  `moduleNameMapper` entry (`^query-string$` → `test/mocks/queryStringMock.js`) that loads the real
  package from the parent repo's `node_modules` via an absolute path and re-exports it with an
  `__esModule`/`default` shape (mirrors the parent repo's `src/dev/jest/mocks/query_string_mock.js`).
  Also relaxed `transformIgnorePatterns` to let Babel transform `query-string` and its ESM-only
  deps (`decode-uri-component`, `filter-obj`, `split-on-first`) rather than ignoring them, so the
  shim can load the real package.

No `package.json` change needed — the plugin inherits the parent repo's Jest 30 stack.

### Issues Resolved

Part of the Jest 30 + jsdom 26 migration campaign (core: opensearch-project/OpenSearch-Dashboards#12381).
<!-- Closes #<this-plugin-issue> -->

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
