### PR TITLE
Fix TS5011 in Cypress E2E by setting rootDir explicitly

### DIFF
--- a/release-notes/opensearch-dashboards-query-workbench.release-notes-3.8.0.0.md
+++ b/release-notes/opensearch-dashboards-query-workbench.release-notes-3.8.0.0.md
@@ -11,3 +11,4 @@ Compatible with OpenSearch and OpenSearch Dashboards version 3.8.0
 
 * Migrate ESLint configuration to ESLint 10 flat config format ([#574](https://github.com/opensearch-project/dashboards-query-workbench/pull/574))
 * Migrate Jest test suite to Jest 30 and jsdom 26 ([#577](https://github.com/opensearch-project/dashboards-query-workbench/pull/577))
+* Fix TS5011 in Cypress E2E by setting rootDir explicitly ([#579](https://github.com/opensearch-project/dashboards-query-workbench/pull/579))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "baseUrl": ".",
     "target": "esnext",
     "module": "commonjs",
+    "rootDir": ".",
     "outDir": "./target",
     "noEmit": true,
     "esModuleInterop": true,


### PR DESCRIPTION
### Description

The **Cypress E2E SQL Workbench Test** workflow fails on `main` during **"Run Cypress tests"**:

```
Your configFile threw an error from: cypress.config.js
The error was thrown while executing your e2e.setupNodeEvents() function:

TSError: ⨯ Unable to compile TypeScript:
error TS5011: The common source directory of 'tsconfig.json' is './.cypress/plugins'.
The 'rootDir' setting must be explicitly set to this or another path to adjust your
output's file layout.
```

Flagged in [#577 (comment)](https://github.com/opensearch-project/dashboards-query-workbench/pull/577#issuecomment-5001058683) as fallout from the OSD TypeScript 6.0.2 upgrade ([OpenSearch-Dashboards#11687](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11687)), not from that PR.

### Root cause

Cypress registers **ts-node** to compile the file `setupNodeEvents` requires (`.cypress/plugins/index.js`). ts-node resolves `tsconfig.json` from the project root, then **force-overrides two options regardless of what that config says** — from `ts-node/dist/configuration.js`:

```js
noEmit: false,
outDir: '.ts-node',
```

Because ts-node always injects an `outDir`, TypeScript must compute a *common source directory* to lay out emitted files. TS 6.0.2 tightened this: it now **errors** instead of silently inferring a value when `rootDir` isn't explicit.

Two things worth noting, since both are natural first guesses that don't work:

- **This is not caused by our own `outDir: "./target"`.** ts-node overrides it with its own value, so removing ours changes nothing.
- **`transpileOnly` does not avoid it.** Cypress already registers ts-node with `transpileOnly: true`; TS5011 is raised during ts-node's *config resolution*, before any type-checking would be skipped.

### Fix

Set `rootDir` explicitly to the plugin root. With `rootDir` known, no common-source-directory inference is needed and the error goes away.

This does **not** affect normal typechecking. `include` pulls in `../../typings/**/*` from the parent repo — outside `rootDir` — but because the config sets `noEmit: true`, `rootDir` is never used for output layout, so no `TS6059` ("not under rootDir") diagnostics are produced. Verified: `tsc -p tsconfig.json` reports **0** TS6059 errors.

### Testing

I replicated Cypress's exact ts-node registration (same `compilerOptions`, `dir`, `transpileOnly`) in a standalone harness, which reproduces the identical error message and passes with this change.

| Check | Before | After |
|---|---|---|
| ts-node harness (mirrors Cypress) | `error TS5011` | ✅ no error |
| `yarn cypress:run` locally | `TSError` at config load (5 occurrences) | ✅ **0** TS errors; compiles and proceeds to server verification |
| `tsc -p tsconfig.json` — TS6059 | n/a | ✅ 0 |
| `yarn build` | pass | ✅ pass |
| `yarn test:jest` | pass | ✅ pass (31 suites, 127 tests, 81 snapshots) |

The local Cypress run then stops at "could not verify that this server is running: http://localhost:5601" — expected, since a local OpenSearch Dashboards instance isn't running. CI provides one, so the E2E job here is the final confirmation.

### Note on the other CI failures

The comment referenced two CI issues. This PR fixes TS5011.

The other — `Get-CI-Image-Tag` and `Run binary installation` failing with *"all actions must be pinned to a full-length commit SHA"* — is caused by **transitive** unpinned actions inside external reusable/composite actions we call, and is fixed separately in #580 (verified: those jobs now pass, and `Run unit tests on linux host` is no longer skipped).

Those jobs will remain red on this PR until #580 merges; they fail during "Set up job" in 3-4s, before any code is checked out, so they are unrelated to this change.

### Check List
- [x] All tests pass
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
