### PR TITLE
Unblock CI by replacing third-party actions with SHA-pinned equivalents

### DIFF
--- a/.github/workflows/sql-workbench-test-build-workflow.yml
+++ b/.github/workflows/sql-workbench-test-build-workflow.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   Get-CI-Image-Tag:
-    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@c2498b758c08fb7bc48476509a5fc1b8dd5f7493 # main
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@761e093b8c1349cc07f21c1d681d3b30bf9e1999 # main
     with:
       product: opensearch-dashboards
 

--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -29,14 +29,14 @@ jobs:
         shell: bash
 
       - name: Run Opensearch
-        uses: derek-ho/start-opensearch@47c6a62637ce79510d7f67ac150639a4510cf694 # v9
+        uses: opensearch-project/opensearch-build/.github/actions/start-opensearch@643b632712710159088d5f0798de7e91c1f2b8f7
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           security-enabled: false
 
       - name: Run Dashboard
         id: setup-dashboards
-        uses: derek-ho/setup-opensearch-dashboards@eee8e92484c4b05a68f363bb662e704f1d2295bc # v2
+        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@643b632712710159088d5f0798de7e91c1f2b8f7
         with:
           plugin_name: ${{ env.PLUGIN_NAME }}
           built_plugin_name: queryWorkbenchDashboards

--- a/release-notes/opensearch-dashboards-query-workbench.release-notes-3.8.0.0.md
+++ b/release-notes/opensearch-dashboards-query-workbench.release-notes-3.8.0.0.md
@@ -12,3 +12,4 @@ Compatible with OpenSearch and OpenSearch Dashboards version 3.8.0
 * Migrate ESLint configuration to ESLint 10 flat config format ([#574](https://github.com/opensearch-project/dashboards-query-workbench/pull/574))
 * Migrate Jest test suite to Jest 30 and jsdom 26 ([#577](https://github.com/opensearch-project/dashboards-query-workbench/pull/577))
 * Fix TS5011 in Cypress E2E by setting rootDir explicitly ([#579](https://github.com/opensearch-project/dashboards-query-workbench/pull/579))
+* Unblock CI by replacing third-party actions with SHA-pinned equivalents ([#580](https://github.com/opensearch-project/dashboards-query-workbench/pull/580))


### PR DESCRIPTION
### Description

Two workflows have been failing on `main` — and on every PR — during **"Set up job"**, before any code is checked out:

**`Get-CI-Image-Tag`** (which also causes `Run unit tests on linux host` to be skipped, since it `needs` this job):
```
The actions iarekylew00t/crane-installer@v1 and actions/checkout@v6 are not allowed in
opensearch-project/dashboards-query-workbench because all actions must be pinned to a
full-length commit SHA.
```

**`Run binary installation`**:
```
The actions actions/setup-java@v4, peternied/download-file@v3, and peternied/action-sleep@v1
are not allowed in opensearch-project/dashboards-query-workbench because all actions must be
pinned to a full-length commit SHA.
```

This is the second of the two CI issues raised in [#577 (comment)](https://github.com/opensearch-project/dashboards-query-workbench/pull/577#issuecomment-5001058683). (The TS5011 Cypress failure is handled separately in #579.)

### Root cause

Every action our workflows reference **directly** was already SHA-pinned by #558. The violations are **transitive** — unpinned third-party actions used *inside* the external reusable workflow and composite actions we call. The org policy resolves those nested references too, so pinning only our own layer isn't enough.

Note the policy targets *third-party* actions; same-org `opensearch-project/...@main` reusable workflow references (backport, pr_review, issue-dedupe) are unaffected and left as-is.

### Fix

**1. `get-ci-image-tag.yml` — version bump is sufficient.**

Our pin (`c2498b7`, 2026-05-21) predated the upstream fix. `opensearch-build` pinned all of its workflow actions in [`761e093`](https://github.com/opensearch-project/opensearch-build/commit/761e093b8c1349cc07f21c1d681d3b30bf9e1999) ("Update build repo all workflows to use SHA", opensearch-build#6253). At that commit both offenders are pinned:

```yaml
uses: iarekylew00t/crane-installer@129958071ac638780427317f25d7c5e66f5e88e4 # v1
uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
```

`dashboards-reporting` already pins this exact commit.

**2. `derek-ho/*` composite actions — version bump does *not* help.**

Both still reference their internals by tag even on their latest versions (`start-opensearch@v10` included), so there is no good version to bump to. `opensearch-build` now hosts maintained equivalents under `.github/actions/` whose internals are fully SHA-pinned (`setup-java@be666c2`, `checkout@df4cb1c`, `setup-node@48b55a0`, `nick-fields/retry@ad98453` — and `peternied/download-file` / `action-sleep` replaced with inline shell).

Switching to those matches what `dashboards-maps` and `anomaly-detection-dashboards-plugin` already do.

### Compatibility

The replacements are drop-in — I verified the interface against the pinned action definitions:

| | Ours | Supported |
|---|---|---|
| `start-opensearch` inputs | `opensearch-version`, `security-enabled` | ✅ (both are its required inputs) |
| `setup-opensearch-dashboards` inputs | `plugin_name`, `built_plugin_name`, `built_plugin_suffix`, `install_zip` | ✅ |
| output consumed | `steps.setup-dashboards.outputs.dashboards-binary-directory` | ✅ still provided |

### Why these SHAs

Both are verified pinned *and* proven under the same org policy — sibling repos using them passed CI on 2026-07-22:

- `761e093...` → `dashboards-reporting` build workflow: ✅ success
- `643b632...` → `anomaly-detection-dashboards-plugin` binary installation: ✅ success

### Testing

These are job-setup-level failures that can only be validated by CI actually running. Both jobs currently die in 3–4s before checking out code; the signal to look for is them progressing past **"Set up job"**. Workflow YAML was validated locally as parseable and the step/output references confirmed intact.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
