### PR TITLE
[AUTO] Add release notes for 3.8.0

### DIFF
--- a/release-notes/opensearch-dashboards-query-workbench.release-notes-3.8.0.0.md
+++ b/release-notes/opensearch-dashboards-query-workbench.release-notes-3.8.0.0.md
@@ -1,0 +1,18 @@
+## Version 3.8.0 Release Notes
+
+Compatible with OpenSearch and OpenSearch Dashboards version 3.8.0
+
+### Enhancements
+
+* Onboard code diff analyzer/reviewer and issue dedupe workflows (dashboards-query-workbench) ([#554](https://github.com/opensearch-project/dashboards-query-workbench/pull/554))
+* Onboard new backport-pr re-usable github workflow (dashboards-query-workbench) ([#568](https://github.com/opensearch-project/dashboards-query-workbench/pull/568))
+
+### Infrastructure
+
+* Adopt ESLint 10 / flat config ([#574](https://github.com/opensearch-project/dashboards-query-workbench/pull/574))
+* Migrate Jest test suite to Jest 30 + jsdom 26 ([#577](https://github.com/opensearch-project/dashboards-query-workbench/pull/577))
+
+### Maintenance
+
+* [AUTO] Increment version to 3.8.0.0 ([#561](https://github.com/opensearch-project/dashboards-query-workbench/pull/561))
+* update deps ([#581](https://github.com/opensearch-project/dashboards-query-workbench/pull/581))


### PR DESCRIPTION
Add release notes for 3.8.0

> **Draft / preview.** OpenSearch 3.8 has not been branch-cut yet (upstream has release branches through `3.7`, no `3.8` branch). These notes are generated from every PR merged to `main` since the 3.7.0 release-notes commit (#560), following `.github/draft-release-notes-config.yml` (label→category mapping, `sort-by: merged_at ascending`). The official `opensearch-ci-bot` `[AUTO]` PR will supersede this at release time.

## Borderline Calls
- **#554 / #568** ("Onboard code diff analyzer/reviewer…", "Onboard new backport-pr re-usable github workflow") are labeled `enhancement`, so they land under **Enhancements** per the config — though functionally they are CI/workflow infrastructure and could arguably sit under **Infrastructure**. Kept under the label to match the bot's behavior.
- Unlabeled PRs categorized by content: ESLint 10 / Jest 30 migrations → **Infrastructure**; version bump (#561) and dependency update (#581) → **Maintenance**.

Category counts: Enhancements 2 · Infrastructure 2 · Maintenance 2 (total 6).
