### PR TITLE
fix: Remove misleading 'this query is not runnable' error suffix

### DIFF
--- a/public/components/Main/main.tsx
+++ b/public/components/Main/main.tsx
@@ -664,10 +664,9 @@ export class Main extends React.Component<MainProps, MainState> {
       );
 
       Promise.all([translationPromise]).then(([translationResponse]) => {
-        const translationResult: Array<ResponseDetail<
-          TranslateResult
-        >> = translationResponse.map((translationResp) =>
-          this.processTranslateResponse(translationResp as IHttpResponse<ResponseData>)
+        const translationResult: Array<ResponseDetail<TranslateResult>> = translationResponse.map(
+          (translationResp) =>
+            this.processTranslateResponse(translationResp as IHttpResponse<ResponseData>)
         );
         const shouldCleanResults = queries === this.state.queries;
         if (shouldCleanResults) {
@@ -900,10 +899,8 @@ export class Main extends React.Component<MainProps, MainState> {
   checkHistoryState = () => {
     if (!this.historyFromRedirection.location.state) return;
 
-    const {
-      language,
-      queryToRun,
-    }: { language: string; queryToRun: string } = this.historyFromRedirection.location.state;
+    const { language, queryToRun }: { language: string; queryToRun: string } =
+      this.historyFromRedirection.location.state;
     if (language === 'sql') {
       this.updateSQLQueries(queryToRun);
 
@@ -977,9 +974,8 @@ export class Main extends React.Component<MainProps, MainState> {
     );
   };
 
-  DataSourceMenu = this.props.dataSourceManagement?.ui?.getDataSourceMenu<
-    DataSourceSelectableConfig
-  >();
+  DataSourceMenu =
+    this.props.dataSourceManagement?.ui?.getDataSourceMenu<DataSourceSelectableConfig>();
 
   render() {
     let page;

--- a/public/components/Main/main.tsx
+++ b/public/components/Main/main.tsx
@@ -161,10 +161,10 @@ interface MainState {
 
 const SUCCESS_MESSAGE = 'Success';
 const errorQueryResponse = (queryResultResponseDetail: ResponseDetail<string>) => {
-  const errorMessage =
-    queryResultResponseDetail.errorMessage +
-    ', this query is not runnable. \n \n' +
-    queryResultResponseDetail.data;
+  let errorMessage = queryResultResponseDetail.errorMessage || 'Unknown error';
+  if (queryResultResponseDetail.data) {
+    errorMessage += '\n\n' + queryResultResponseDetail.data;
+  }
   return errorMessage;
 };
 


### PR DESCRIPTION
The errorQueryResponse function unconditionally appended ', this query is not runnable' to all error messages, making non-permission failures (timeouts, backend errors) appear as authorization issues. This confused users into thinking they had permission problems when the actual cause was different.

Now the error message shows the actual server error without the misleading suffix. Additional error data is still appended when available.

Resolves opensearch-project#584

### Description
  The `errorQueryResponse` function unconditionally appended `, this query is not runnable` to all error messages. This made non-permission failures (backend timeouts, server errors, circuit breaker trips) appear as authorization issues, confusing users into thinking they had permission problems when the actual cause was different.
  
  The fix removes the hardcoded suffix and shows the actual server error message. Additional error details are still appended when available.
  
  ### Issues Resolved
  Resolves #584
  
  ### Check List
  - [x] New functionality includes testing.
    - [ ] All tests pass, including unit test, integration test and doctest
  - [ ] New functionality has been documented.
    - [ ] New functionality has javadoc added
    - [ ] New functionality has user manual doc added
  - [x] Commits are signed per the DCO using --signoff 
 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).