### PR TITLE
Add Jialiang Liang (RyanL1997) as a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @pjfitzgibbons @ps48 @kavithacm @derek-ho @joshuali925 @dai-chen @YANG-DB @rupal-bq @mengweieric @vamsi-amazon @swiddis @penghuo @seankao-az @Yury-Fridlyand @anirudha @paulstn @sumukhswamy @RyanL1997
+*   @ps48 @joshuali925 @dai-chen @mengweieric @vamsi-amazon @swiddis @penghuo @seankao-az @anirudha @sumukhswamy @RyanL1997

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @ps48 @joshuali925 @dai-chen @mengweieric @vamsi-amazon @swiddis @penghuo @seankao-az @anirudha @sumukhswamy @RyanL1997
+*   @ps48 @joshuali925 @dai-chen @mengweieric @vamsi-amazon @swiddis @penghuo @anirudha @sumukhswamy @RyanL1997

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @pjfitzgibbons @ps48 @kavithacm @derek-ho @joshuali925 @dai-chen @YANG-DB @rupal-bq @mengweieric @vamsi-amazon @swiddis @penghuo @seankao-az @Yury-Fridlyand @anirudha @paulstn @sumukhswamy
+*   @pjfitzgibbons @ps48 @kavithacm @derek-ho @joshuali925 @dai-chen @YANG-DB @rupal-bq @mengweieric @vamsi-amazon @swiddis @penghuo @seankao-az @Yury-Fridlyand @anirudha @paulstn @sumukhswamy @RyanL1997

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @ps48 @joshuali925 @dai-chen @mengweieric @vamsi-amazon @swiddis @penghuo @anirudha @sumukhswamy @RyanL1997
+*   @ps48 @joshuali925 @dai-chen @mengweieric @vamsimanohar @swiddis @penghuo @anirudha @sumukhswamy @RyanL1997

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -24,6 +24,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Anirudha Jadhav         | [anirudha](https://github.com/anirudha)             | Amazon      |
 | Paul Sebastian          | [paulstn](https://github.com/paulstn)               | Amazon      |
 | Sumukh Hanumantha Swamy | [sumukhswamy](https://github.com/sumukhswamy)       | Amazon      |
+| Jialiang Liang          | [RyanL1997](https://github.com/RyanL1997)           | Amazon      |
 
 ## Emeritus Maintainers
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,35 +4,35 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer              | GitHub ID                                           | Affiliation |
-| ----------------------- | --------------------------------------------------- | ----------- |
-| Eric Wei                | [mengweieric](https://github.com/mengweieric)       | Amazon      |
-| Joshua Li               | [joshuali925](https://github.com/joshuali925)       | Amazon      |
-| Shenoy Pratik           | [ps48](https://github.com/ps48)                     | Amazon      |
-| Kavitha Mohan           | [kavithacm](https://github.com/kavithacm)           | Amazon      |
-| Rupal Mahajan           | [rupal-bq](https://github.com/rupal-bq)             | Amazon      |
-| Derek Ho                | [derek-ho](https://github.com/derek-ho)             | Amazon      |
-| Lior Perry              | [YANG-DB](https://github.com/YANG-DB)               | Amazon      |
-| Peter Fitzgibbons       | [pjfitzgibbons](https://github.com/pjfitzgibbons)   | Amazon      |
-| Simeon Widdis           | [swiddis](https://github.com/swiddis)               | Amazon      |
-| Chen Dai                | [dai-chen](https://github.com/dai-chen)             | Amazon      |
-| Vamsi Manohar           | [vamsimanohar](https://github.com/vamsimanohar)     | Amazon      |
-| Peng Huo                | [penghuo](https://github.com/penghuo)               | Amazon      |
-| Sean Kao                | [seankao-az](https://github.com/seankao-az)         | Amazon      |
-| Max Ksyunz              | [MaxKsyunz](https://github.com/MaxKsyunz)           | BitQuill    |
-| Yury Fridlyand          | [Yury-Fridlyand](https://github.com/Yury-Fridlyand) | BitQuill    |
-| Anirudha Jadhav         | [anirudha](https://github.com/anirudha)             | Amazon      |
-| Paul Sebastian          | [paulstn](https://github.com/paulstn)               | Amazon      |
-| Sumukh Hanumantha Swamy | [sumukhswamy](https://github.com/sumukhswamy)       | Amazon      |
-| Jialiang Liang          | [RyanL1997](https://github.com/RyanL1997)           | Amazon      |
+| Maintainer              | GitHub ID                                       | Affiliation |
+| ----------------------- | ----------------------------------------------- | ----------- |
+| Eric Wei                | [mengweieric](https://github.com/mengweieric)   | Amazon      |
+| Joshua Li               | [joshuali925](https://github.com/joshuali925)   | Amazon      |
+| Shenoy Pratik           | [ps48](https://github.com/ps48)                 | Amazon      |
+| Simeon Widdis           | [swiddis](https://github.com/swiddis)           | Amazon      |
+| Chen Dai                | [dai-chen](https://github.com/dai-chen)         | Amazon      |
+| Vamsi Manohar           | [vamsimanohar](https://github.com/vamsimanohar) | Amazon      |
+| Peng Huo                | [penghuo](https://github.com/penghuo)           | Amazon      |
+| Sean Kao                | [seankao-az](https://github.com/seankao-az)     | Amazon      |
+| Max Ksyunz              | [MaxKsyunz](https://github.com/MaxKsyunz)       | BitQuill    |
+| Anirudha Jadhav         | [anirudha](https://github.com/anirudha)         | Amazon      |
+| Sumukh Hanumantha Swamy | [sumukhswamy](https://github.com/sumukhswamy)   | Amazon      |
+| Jialiang Liang          | [RyanL1997](https://github.com/RyanL1997)       | Amazon      |
 
 ## Emeritus Maintainers
 
-| Maintainer       | GitHub ID                                       | Affiliation |
-| ---------------- | ----------------------------------------------- | ----------- |
-| Charlotte Henkle | [CEHENKLE](https://github.com/CEHENKLE)         | Amazon      |
-| Nick Knize       | [nknize](https://github.com/nknize)             | Amazon      |
-| David Cui        | [davidcui1225](https://github.com/davidcui1225) | Amazon      |
-| Eugene Lee       | [eugenesk24](https://github.com/eugenesk24)     | Amazon      |
-| Zhongnan Su      | [zhongnansu](https://github.com/zhongnansu)     | Amazon      |
-| Chloe Zhang      | [chloe-zh](https://github.com/chloe-zh)         | Amazon      |
+| Maintainer        | GitHub ID                                           | Affiliation |
+| ----------------- | --------------------------------------------------- | ----------- |
+| Charlotte Henkle  | [CEHENKLE](https://github.com/CEHENKLE)             | Amazon      |
+| Nick Knize        | [nknize](https://github.com/nknize)                 | Amazon      |
+| David Cui         | [davidcui1225](https://github.com/davidcui1225)     | Amazon      |
+| Eugene Lee        | [eugenesk24](https://github.com/eugenesk24)         | Amazon      |
+| Zhongnan Su       | [zhongnansu](https://github.com/zhongnansu)         | Amazon      |
+| Chloe Zhang       | [chloe-zh](https://github.com/chloe-zh)             | Amazon      |
+| Peter Fitzgibbons | [pjfitzgibbons](https://github.com/pjfitzgibbons)   | Amazon      |
+| Kavitha Mohan     | [kavithacm](https://github.com/kavithacm)           | Amazon      |
+| Derek Ho          | [derek-ho](https://github.com/derek-ho)             | Amazon      |
+| Lior Perry        | [YANG-DB](https://github.com/YANG-DB)               | Amazon      |
+| Rupal Mahajan     | [rupal-bq](https://github.com/rupal-bq)             | Amazon      |
+| Yury Fridlyand    | [Yury-Fridlyand](https://github.com/Yury-Fridlyand) | BitQuill    |
+| Paul Sebastian    | [paulstn](https://github.com/paulstn)               | Amazon      |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,8 +13,6 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Chen Dai                | [dai-chen](https://github.com/dai-chen)         | Amazon      |
 | Vamsi Manohar           | [vamsimanohar](https://github.com/vamsimanohar) | Amazon      |
 | Peng Huo                | [penghuo](https://github.com/penghuo)           | Amazon      |
-| Sean Kao                | [seankao-az](https://github.com/seankao-az)     | Amazon      |
-| Max Ksyunz              | [MaxKsyunz](https://github.com/MaxKsyunz)       | BitQuill    |
 | Anirudha Jadhav         | [anirudha](https://github.com/anirudha)         | Amazon      |
 | Sumukh Hanumantha Swamy | [sumukhswamy](https://github.com/sumukhswamy)   | Amazon      |
 | Jialiang Liang          | [RyanL1997](https://github.com/RyanL1997)       | Amazon      |
@@ -36,3 +34,5 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Rupal Mahajan     | [rupal-bq](https://github.com/rupal-bq)             | Amazon      |
 | Yury Fridlyand    | [Yury-Fridlyand](https://github.com/Yury-Fridlyand) | BitQuill    |
 | Paul Sebastian    | [paulstn](https://github.com/paulstn)               | Amazon      |
+| Max Ksyunz        | [MaxKsyunz](https://github.com/MaxKsyunz)           | BitQuill    |
+| Sean Kao          | [seankao-az](https://github.com/seankao-az)         | Amazon      |


### PR DESCRIPTION
### Description

Adds [Jialiang Liang](https://github.com/RyanL1997) (`RyanL1997`) as a maintainer of the dashboards-query-workbench repository.

Jialiang has been an active contributor with 15 merged PRs spanning CI/CD workflows (E2E Cypress, FTR), CVE remediation, dependency syncs, and single-version OSD capability gating. A maintainer vote was held via email and passed with 3 +1 votes (in addition to the proposer).

Contributions: https://github.com/opensearch-project/dashboards-query-workbench/commits?author=RyanL1997

Changes:
- Add Jialiang Liang (`RyanL1997`) to `MAINTAINERS.md`
- Add `@RyanL1997` to `.github/CODEOWNERS`

A corresponding GitHub access request will be filed in the [opensearch-project/.github](https://github.com/opensearch-project/.github) repository.

### Check List
- [x] All tests pass
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.